### PR TITLE
SBT plugin should add library dependency of corresponding runtime.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ inThisBuild(
   ))
 
 lazy val root = project.in(file("."))
-  .enablePlugins(GitVersioning)
+  .enablePlugins(GitVersioning, BuildInfoPlugin)
   .settings(
     sonatypeProfileName := "org.lyranthe",
     skip in publish := true,
@@ -29,11 +29,12 @@ lazy val root = project.in(file("."))
   .aggregate(`sbt-java-gen`, `java-runtime`)
 
 lazy val `sbt-java-gen` = project
-  .enablePlugins(GitVersioning)
+  .enablePlugins(GitVersioning, BuildInfoPlugin)
   .settings(
     publishTo := sonatypePublishTo.value,
     sbtPlugin := true,
     crossSbtVersions := List(sbtVersion.value, "0.13.17"),
+    buildInfoPackage := "org.lyranthe.fs2_grpc.buildinfo",
     addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.18"),
     libraryDependencies ++= List(
       "io.grpc"              % "grpc-core"       % "1.11.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,9 @@ addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype" % "2.3")
 addSbtPlugin("com.jsuereth"     % "sbt-pgp"      % "1.1.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git"      % "0.9.3")
 
-addSbtPlugin("com.geirsson"     % "sbt-scalafmt" % "1.4.0")
-addSbtPlugin("com.timushev.sbt" % "sbt-updates"  % "0.3.4")
+addSbtPlugin("com.eed3si9n"     % "sbt-buildinfo" % "0.8.0")
+addSbtPlugin("com.geirsson"     % "sbt-scalafmt"  % "1.4.0")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates"   % "0.3.4")
 
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.3")
 

--- a/sbt-java-gen/src/main/scala/Fs2GrpcPlugin.scala
+++ b/sbt-java-gen/src/main/scala/Fs2GrpcPlugin.scala
@@ -66,7 +66,7 @@ object Fs2GrpcPlugin extends AutoPlugin {
     libraryDependencies ++= List(
       "io.grpc"               % "grpc-core"             % scalapb.compiler.Version.grpcJavaVersion,
       "io.grpc"               % "grpc-stub"             % scalapb.compiler.Version.grpcJavaVersion,
-      "org.lyranthe.fs2-grpc" %% "java-runtime"         % "0.1.0-SNAPSHOT",
+      "org.lyranthe.fs2-grpc" %% "java-runtime"         % org.lyranthe.fs2_grpc.buildinfo.BuildInfo.version,
       "com.thesamet.scalapb"  %% "scalapb-runtime"      % scalapb.compiler.Version.scalapbVersion,
       "com.thesamet.scalapb"  %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion
     )


### PR DESCRIPTION
This uses sbt-buildinfo to get the version information from SBT and inject it into the SBT plugin.