### PR TITLE
Make sure trailers are not null when closing stream.

### DIFF
--- a/java-runtime/src/main/scala/server/Fs2ServerCallListener.scala
+++ b/java-runtime/src/main/scala/server/Fs2ServerCallListener.scala
@@ -12,9 +12,9 @@ private[server] trait Fs2ServerCallListener[F[_], G[_], Request, Response] {
   def reportError(t: Throwable)(implicit F: Sync[F]): F[Unit] = {
     t match {
       case ex: StatusException =>
-        call.closeStream(ex.getStatus, ex.getTrailers)
+        call.closeStream(ex.getStatus, Option(ex.getTrailers).getOrElse(new Metadata()))
       case ex: StatusRuntimeException =>
-        call.closeStream(ex.getStatus, ex.getTrailers)
+        call.closeStream(ex.getStatus, Option(ex.getTrailers).getOrElse(new Metadata()))
       case ex =>
         // TODO: Customize failure trailers?
         call.closeStream(Status.INTERNAL.withDescription(ex.getMessage).withCause(ex), new Metadata())


### PR DESCRIPTION
grpc-java expects that status and trailers are non-null when closing the stream:
https://github.com/grpc/grpc-java/blob/master/core/src/main/java/io/grpc/internal/AbstractServerStream.java#L128

If the exception is raised like
```scala
io.grpc.Status.INTERNAL
  .withDescription("raising error")
  .asRuntimeException())
```
then this will not actually close the stream because trailers is null.

Due to the signature of the stream, Status-based exceptions are currently the only way to signal specific types of gRPC failure.