### PR TITLE
Updated SBT plugin API and features

### DIFF
--- a/sbt-java-gen/src/main/scala/Fs2GrpcPlugin.scala
+++ b/sbt-java-gen/src/main/scala/Fs2GrpcPlugin.scala
@@ -4,25 +4,31 @@ import com.google.protobuf.Descriptors.FileDescriptor
 import com.google.protobuf.ExtensionRegistry
 import com.google.protobuf.compiler.PluginProtos
 import com.google.protobuf.compiler.PluginProtos.{CodeGeneratorRequest, CodeGeneratorResponse}
-import protocbridge.{Artifact, JvmGenerator, ProtocCodeGenerator}
+import org.lyranthe.fs2_grpc.java_runtime.sbt_gen.Fs2GrpcPlugin.autoImport.scalapbCodeGenerators
+import protocbridge.{Artifact, JvmGenerator, ProtocCodeGenerator, Target}
 import sbt._
 import sbt.Keys._
-import scalapb.compiler.FunctionalPrinter
+import sbt.plugins.JvmPlugin
+import sbtprotoc.ProtocPlugin.autoImport.PB
+import scalapb.compiler.{FunctionalPrinter, GeneratorException, GeneratorParams, ProtobufGenerator}
 import scalapb.options.compiler.Scalapb
 
 import scala.collection.JavaConverters._
 
+sealed trait CodeGeneratorOption extends Product with Serializable
+
 object Fs2CodeGenerator extends ProtocCodeGenerator {
 
-  def generateServiceFiles(file: FileDescriptor): Seq[PluginProtos.CodeGeneratorResponse.File] = {
+  def generateServiceFiles(file: FileDescriptor,
+                           params: GeneratorParams): Seq[PluginProtos.CodeGeneratorResponse.File] = {
     println("Services: " + file.getServices.asScala)
     file.getServices.asScala.map { service =>
-      val p = new Fs2GrpcServicePrinter(service)
+      val p = new Fs2GrpcServicePrinter(service, params)
 
       import p.{FileDescriptorPimp, ServiceDescriptorPimp}
       val code = p.printService(FunctionalPrinter()).result()
       val b    = CodeGeneratorResponse.File.newBuilder()
-      b.setName(file.scalaDirectory + "/Fs2" + service.objectName + ".scala")
+      b.setName(file.scalaDirectory + "/" + service.objectName + "Fs2.scala")
       b.setContent(code)
       println(b.getName)
       b.build
@@ -30,15 +36,29 @@ object Fs2CodeGenerator extends ProtocCodeGenerator {
   }
 
   def handleCodeGeneratorRequest(request: PluginProtos.CodeGeneratorRequest): PluginProtos.CodeGeneratorResponse = {
-    val filesByName: Map[String, FileDescriptor] =
-      request.getProtoFileList.asScala.foldLeft[Map[String, FileDescriptor]](Map.empty) {
-        case (acc, fp) =>
-          val deps = fp.getDependencyList.asScala.map(acc)
-          acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps.toArray))
-      }
+    val b = CodeGeneratorResponse.newBuilder
+    ProtobufGenerator.parseParameters(request.getParameter) match {
+      case Right(params) =>
+        try {
+          val filesByName: Map[String, FileDescriptor] =
+            request.getProtoFileList.asScala.foldLeft[Map[String, FileDescriptor]](Map.empty) {
+              case (acc, fp) =>
+                val deps = fp.getDependencyList.asScala.map(acc)
+                acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps.toArray))
+            }
 
-    val files = request.getFileToGenerateList.asScala.map(filesByName).flatMap(generateServiceFiles)
-    PluginProtos.CodeGeneratorResponse.newBuilder.addAllFile(files.asJava).build()
+          val files = request.getFileToGenerateList.asScala.map(filesByName).flatMap(generateServiceFiles(_, params))
+          b.addAllFile(files.asJava)
+        } catch {
+          case e: GeneratorException =>
+            b.setError(e.message)
+        }
+
+      case Left(error) =>
+        b.setError(error)
+    }
+
+    b.build()
   }
 
   override def run(req: Array[Byte]): Array[Byte] = {
@@ -54,15 +74,75 @@ object Fs2CodeGenerator extends ProtocCodeGenerator {
   )
 }
 
-object Fs2GrpcPlugin extends AutoPlugin {
-  object autoImport {
-    val fs2CodeGenerator: (JvmGenerator, Seq[String]) = (JvmGenerator("fs2-grpc", Fs2CodeGenerator), Seq.empty)
-  }
-
-  override def requires = sbtprotoc.ProtocPlugin
-  override def trigger  = AllRequirements
+object Fs2Grpc extends AutoPlugin {
+  override def requires = Fs2GrpcPlugin
+  override def trigger  = NoTrigger
 
   override def projectSettings: Seq[Def.Setting[_]] = List(
+    PB.targets := scalapbCodeGenerators.value
+  )
+}
+
+object Fs2GrpcPlugin extends AutoPlugin {
+  object autoImport {
+    object CodeGeneratorOption {
+      case object FlatPackage extends CodeGeneratorOption {
+        override def toString = "flat_package"
+      }
+      case object JavaConversions extends CodeGeneratorOption {
+        override def toString: String = "java_conversions"
+      }
+      case object Grpc extends CodeGeneratorOption {
+        override def toString: String = "grpc"
+      }
+      case object Fs2Grpc extends CodeGeneratorOption {
+        override def toString: String = "fs2_grpc"
+      }
+      case object SingleLineToProtoString extends CodeGeneratorOption {
+        override def toString: String = "single_line_to_proto_string"
+      }
+      case object AsciiFormatToString extends CodeGeneratorOption {
+        override def toString: String = "ascii_format_to_string"
+      }
+    }
+
+    val scalapbCodeGeneratorOptions =
+      settingKey[Seq[CodeGeneratorOption]]("Settings for scalapb/fs2-grpc code generation")
+    val scalapbProtobufDirectory =
+      settingKey[File]("Directory containing protobuf files for scalapb")
+    val scalapbCodeGenerators =
+      settingKey[Seq[Target]]("Code generators for scalapb")
+  }
+  import autoImport._
+
+  override def requires = sbtprotoc.ProtocPlugin && JvmPlugin
+  override def trigger  = NoTrigger
+
+  def convertOptionsToScalapbGen(options: Set[CodeGeneratorOption]): (JvmGenerator, Seq[String]) = {
+    scalapb.gen(
+      flatPackage = options(CodeGeneratorOption.FlatPackage),
+      javaConversions = options(CodeGeneratorOption.JavaConversions),
+      grpc = options(CodeGeneratorOption.Grpc),
+      singleLineToProtoString = options(CodeGeneratorOption.SingleLineToProtoString),
+      asciiFormatToString = options(CodeGeneratorOption.AsciiFormatToString)
+    )
+  }
+
+  override def projectSettings: Seq[Def.Setting[_]] = List(
+    scalapbProtobufDirectory := (sourceManaged in Compile).value / "scalapb",
+    scalapbCodeGenerators := {
+      Target(convertOptionsToScalapbGen(scalapbCodeGeneratorOptions.value.toSet),
+             (sourceManaged in Compile).value / "scalapb") ::
+        Option(
+        Target(
+          (JvmGenerator("scala-fs2-grpc", Fs2CodeGenerator),
+           scalapbCodeGeneratorOptions.value.filterNot(_ == CodeGeneratorOption.Fs2Grpc).map(_.toString)),
+          (sourceManaged in Compile).value / "fs2-grpc"
+        ))
+        .filter(_ => scalapbCodeGeneratorOptions.value.contains(CodeGeneratorOption.Fs2Grpc))
+        .toList
+    },
+    scalapbCodeGeneratorOptions := Seq(CodeGeneratorOption.Grpc, CodeGeneratorOption.Fs2Grpc),
     libraryDependencies ++= List(
       "io.grpc"               % "grpc-core"             % scalapb.compiler.Version.grpcJavaVersion,
       "io.grpc"               % "grpc-stub"             % scalapb.compiler.Version.grpcJavaVersion,

--- a/sbt-java-gen/src/main/scala/GrpcServicePrinter.scala
+++ b/sbt-java-gen/src/main/scala/GrpcServicePrinter.scala
@@ -4,7 +4,7 @@ import com.google.protobuf.Descriptors.{MethodDescriptor, ServiceDescriptor}
 import scalapb.compiler.FunctionalPrinter.PrinterEndo
 import scalapb.compiler.{DescriptorPimps, FunctionalPrinter, GeneratorParams, StreamType}
 
-class Fs2GrpcServicePrinter(service: ServiceDescriptor) extends DescriptorPimps {
+class Fs2GrpcServicePrinter(service: ServiceDescriptor, override val params: GeneratorParams) extends DescriptorPimps {
   private[this] def serviceMethodSignature(method: MethodDescriptor) = {
     s"def ${method.name}" + (method.streamType match {
       case StreamType.Unary =>
@@ -94,7 +94,4 @@ class Fs2GrpcServicePrinter(service: ServiceDescriptor) extends DescriptorPimps 
       .call(serviceTrait)
       .call(serviceObject)
   }
-
-  // Not used, but required by DescriptorPimps
-  override def params: GeneratorParams = GeneratorParams()
 }


### PR DESCRIPTION
Some of these features wrap around scalapb's plugin, offering a more
SBT-ish API.

Two AutoPlugins:
 - Fs2GrpcPlugin (enabled by default) with three settings (w/ useful defaults)
   scalapbCodeGeneratorOptions - Settings for code generation
   scalapbProtobufDirectory - Directory containing protocol buffer files
   scalapbCodeGenerators - Code generators for scalapb and fs2-grpc

 - Fs2Grpc (enabled on demand)
   Sets PB.targets to point at the values from scalapbCodeGenerators

Example project after this:
```scala
lazy val protobuf =
  project
    .in(file("."))
    .enablePlugins(Fs2Grpc)
    .settings(
      scalapbCodeGeneratorOptions += CodeGeneratorOption.FlatPackage
    )
```