### PR TITLE
Bump library versions, remove unused build dependencies.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val `sbt-java-gen` = project
     addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.18"),
     libraryDependencies ++= List(
       "io.grpc"              % "grpc-core"       % "1.11.0",
-      "com.thesamet.scalapb" %% "compilerplugin" % "0.7.1"
+      "com.thesamet.scalapb" %% "compilerplugin" % "0.7.2"
     )
   )
 
@@ -51,10 +51,11 @@ lazy val `java-runtime` = project
     publishTo := sonatypePublishTo.value,
     libraryDependencies ++= List(
       "co.fs2"        %% "fs2-core"         % "0.10.3",
+      "org.typelevel" %% "cats-effect"      % "0.10.1",
+      "org.typelevel" %% "cats-effect-laws" % "0.10.1" % "test",
       "io.grpc"       % "grpc-core"         % "1.11.0",
       "io.grpc"       % "grpc-netty-shaded" % "1.11.0" % "test",
-      "io.monix"      %% "minitest"         % "2.1.1" % "test",
-      "org.typelevel" %% "cats-effect-laws" % "0.10" % "test"
+      "io.monix"      %% "minitest"         % "2.1.1"  % "test"
     ),
     testFrameworks += new TestFramework("minitest.runner.Framework"),
     addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.6" cross CrossVersion.binary)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.1.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,11 +2,8 @@ addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype" % "2.3")
 addSbtPlugin("com.jsuereth"     % "sbt-pgp"      % "1.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git"      % "0.9.3")
 
-addSbtPlugin("com.eed3si9n"     % "sbt-buildinfo" % "0.8.0")
+addSbtPlugin("com.eed3si9n"     % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.geirsson"     % "sbt-scalafmt"  % "1.4.0")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates"   % "0.3.4")
 
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.3")
-
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.18")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.1"


### PR DESCRIPTION
scalapb       0.7.1 -> 0.7.2
cats-effect   0.10  -> 0.10.1
sbt-buildinfo 0.8.0 -> 0.9.0
sbt           1.1.2 -> 1.1.4

Removes unneeded protoc/etc. from build.