### PR TITLE
Add MiMa to build.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,7 @@ lazy val `java-runtime` = project
       "io.grpc"       % "grpc-netty-shaded" % "1.12.0" % "test",
       "io.monix"      %% "minitest"         % "2.1.1"  % "test"
     ),
+    mimaPreviousArtifacts := Set(organization.value %% name.value % "0.3.0"),
     testFrameworks += new TestFramework("minitest.runner.Framework"),
     addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.6" cross CrossVersion.binary)
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,6 @@ addSbtPlugin("com.eed3si9n"     % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.geirsson"     % "sbt-scalafmt"  % "1.4.0")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates"   % "0.3.4")
 
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
+
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.3")


### PR DESCRIPTION
Add MiMa to build to check for binary issues (currently comparing with 0.3.0).