### PR TITLE
Update Travis versions (scala and JDK updates)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: scala
 scala:
    - 2.11.12
-   - 2.12.5
-jdk: oraclejdk8
+   - 2.12.6
+jdk:
+  - oraclejdk8
+  - oraclejdk10
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test
   - cd example && sbt ++$TRAVIS_SCALA_VERSION test


### PR DESCRIPTION
Adds Oracle JDK 10 to build matrix, updates to scala 2.12.6