### PR TITLE
Use grpcJavaVersion from scalapb, expose in SBT for fs2-grpc users

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val `sbt-java-gen` = project
     crossSbtVersions := List(sbtVersion.value, "0.13.17"),
     buildInfoPackage := "org.lyranthe.fs2_grpc.buildinfo",
     addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.18"),
-    libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.4"
+    libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % scalapb.compiler.Version.scalapbVersion
   )
 
 lazy val `java-runtime` = project
@@ -50,9 +50,9 @@ lazy val `java-runtime` = project
       "co.fs2"        %% "fs2-core"         % "0.10.4",
       "org.typelevel" %% "cats-effect"      % "0.10.1",
       "org.typelevel" %% "cats-effect-laws" % "0.10.1" % "test",
-      "io.grpc"       % "grpc-core"         % "1.12.0",
-      "io.grpc"       % "grpc-netty-shaded" % "1.12.0" % "test",
-      "io.monix"      %% "minitest"         % "2.1.1"  % "test"
+      "io.grpc"       % "grpc-core"         % scalapb.compiler.Version.grpcJavaVersion,
+      "io.grpc"       % "grpc-netty-shaded" % scalapb.compiler.Version.grpcJavaVersion % "test",
+      "io.monix"      %% "minitest"         % "2.1.1" % "test"
     ),
     mimaPreviousArtifacts := Set(organization.value %% name.value % "0.3.0"),
     testFrameworks += new TestFramework("minitest.runner.Framework"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("com.timushev.sbt" % "sbt-updates"   % "0.3.4")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.3")
+
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.4"

--- a/sbt-java-gen/src/main/scala/Fs2GrpcPlugin.scala
+++ b/sbt-java-gen/src/main/scala/Fs2GrpcPlugin.scala
@@ -85,6 +85,8 @@ object Fs2Grpc extends AutoPlugin {
 
 object Fs2GrpcPlugin extends AutoPlugin {
   object autoImport {
+    val grpcJavaVersion: String = scalapb.compiler.Version.grpcJavaVersion
+
     object CodeGeneratorOption {
       case object FlatPackage extends CodeGeneratorOption {
         override def toString = "flat_package"


### PR DESCRIPTION
This reduces chances of incompatible versions of grpc-java being used between scalapb, generator, and runtime system.

Also, exposes the version used through the SBT plugin, so you can write

```scala
libraryDependencies += "io.grpc" % "grpc-netty" % grpcJavaVersion
