### PR TITLE
scalapb upgrade

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,4 +10,4 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.3")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.4"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.0"

--- a/sbt-java-gen/src/main/scala/GrpcServicePrinter.scala
+++ b/sbt-java-gen/src/main/scala/GrpcServicePrinter.scala
@@ -2,19 +2,22 @@ package org.lyranthe.fs2_grpc.java_runtime.sbt_gen
 
 import com.google.protobuf.Descriptors.{MethodDescriptor, ServiceDescriptor}
 import scalapb.compiler.FunctionalPrinter.PrinterEndo
-import scalapb.compiler.{DescriptorPimps, FunctionalPrinter, GeneratorParams, StreamType}
+import scalapb.compiler.{DescriptorImplicits, FunctionalPrinter, StreamType}
 
-class Fs2GrpcServicePrinter(service: ServiceDescriptor, override val params: GeneratorParams) extends DescriptorPimps {
+class Fs2GrpcServicePrinter(service: ServiceDescriptor, di: DescriptorImplicits){
+  import di._
+
   private[this] def serviceMethodSignature(method: MethodDescriptor) = {
+
+    val scalaInType   = method.inputType.scalaType
+    val scalaOutType  = method.outputType.scalaType
+    val clientHeaders = "clientHeaders: _root_.io.grpc.Metadata"
+
     s"def ${method.name}" + (method.streamType match {
-      case StreamType.Unary =>
-        s"(request: ${method.scalaIn}, clientHeaders: _root_.io.grpc.Metadata): F[${method.scalaOut}]"
-      case StreamType.ClientStreaming =>
-        s"(request: _root_.fs2.Stream[F, ${method.scalaIn}], clientHeaders: _root_.io.grpc.Metadata): F[${method.scalaOut}]"
-      case StreamType.ServerStreaming =>
-        s"(request: ${method.scalaIn}, clientHeaders: _root_.io.grpc.Metadata): _root_.fs2.Stream[F, ${method.scalaOut}]"
-      case StreamType.Bidirectional =>
-        s"(request: _root_.fs2.Stream[F, ${method.scalaIn}], clientHeaders: _root_.io.grpc.Metadata): _root_.fs2.Stream[F, ${method.scalaOut}]"
+      case StreamType.Unary           => s"(request: $scalaInType, $clientHeaders): F[$scalaOutType]"
+      case StreamType.ClientStreaming => s"(request: _root_.fs2.Stream[F, $scalaInType], $clientHeaders): F[$scalaOutType]"
+      case StreamType.ServerStreaming => s"(request: $scalaInType, $clientHeaders): _root_.fs2.Stream[F, $scalaOutType]"
+      case StreamType.Bidirectional   => s"(request: _root_.fs2.Stream[F, $scalaInType], $clientHeaders): _root_.fs2.Stream[F, $scalaOutType]"
     })
   }
 


### PR DESCRIPTION
 - upgrade to ScalaPB 0.8.0

 - adjust `Fs2GrpcPlugin` and `GrpcServicePrinter` to
   changes done with respect to `DescriptorImplicits`
   class that previously was trait `DescriptorPimps`.