### PR TITLE
Move forward

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,9 +47,9 @@ lazy val `java-runtime` = project
     crossScalaVersions := List(scalaVersion.value, "2.11.12"),
     publishTo := sonatypePublishTo.value,
     libraryDependencies ++= List(
-      "co.fs2"        %% "fs2-core"         % "0.10.5",
-      "org.typelevel" %% "cats-effect"      % "0.10.1",
-      "org.typelevel" %% "cats-effect-laws" % "0.10.1" % "test",
+      "co.fs2"        %% "fs2-core"         % "1.0.0-M5",
+      "org.typelevel" %% "cats-effect"      % "1.0.0",
+      "org.typelevel" %% "cats-effect-laws" % "1.0.0" % "test",
       "io.grpc"       % "grpc-core"         % scalapb.compiler.Version.grpcJavaVersion,
       "io.grpc"       % "grpc-netty-shaded" % scalapb.compiler.Version.grpcJavaVersion % "test",
       "io.monix"      %% "minitest"         % "2.1.1" % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -43,18 +43,18 @@ lazy val `sbt-java-gen` = project
 lazy val `java-runtime` = project
   .enablePlugins(GitVersioning)
   .settings(
-    scalaVersion := "2.12.6",
+    scalaVersion := "2.12.7",
     crossScalaVersions := List(scalaVersion.value, "2.11.12"),
     publishTo := sonatypePublishTo.value,
     libraryDependencies ++= List(
-      "co.fs2"        %% "fs2-core"         % "1.0.0-M5",
+      "co.fs2"        %% "fs2-core"         % "1.0.0",
       "org.typelevel" %% "cats-effect"      % "1.0.0",
       "org.typelevel" %% "cats-effect-laws" % "1.0.0" % "test",
       "io.grpc"       % "grpc-core"         % scalapb.compiler.Version.grpcJavaVersion,
       "io.grpc"       % "grpc-netty-shaded" % scalapb.compiler.Version.grpcJavaVersion % "test",
-      "io.monix"      %% "minitest"         % "2.1.1" % "test"
+      "io.monix"      %% "minitest"         % "2.2.1" % "test"
     ),
     mimaPreviousArtifacts := Set(organization.value %% name.value % "0.3.0"),
     testFrameworks += new TestFramework("minitest.runner.Framework"),
-    addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.7" cross CrossVersion.binary)
+    addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.8" cross CrossVersion.binary)
   )

--- a/java-runtime/src/main/scala/client/Fs2StreamClientCallListener.scala
+++ b/java-runtime/src/main/scala/client/Fs2StreamClientCallListener.scala
@@ -1,15 +1,13 @@
 package org.lyranthe.fs2_grpc.java_runtime.client
 
 import cats.arrow.FunctionK
-import cats.effect.{IO, LiftIO}
+import cats.effect.{Concurrent, ContextShift, IO, LiftIO}
 import cats.implicits._
-import fs2.{Pull, Stream}
+import fs2.concurrent.Queue
+import fs2.{Pull, RaiseThrowable, Stream}
 import io.grpc.{ClientCall, Metadata, Status}
 
-import scala.concurrent.ExecutionContext
-
-class Fs2StreamClientCallListener[Response](request: Int => Unit,
-                                            queue: fs2.async.mutable.Queue[IO, Either[GrpcStatus, Response]])
+class Fs2StreamClientCallListener[Response](request: Int => Unit, queue: Queue[IO, Either[GrpcStatus, Response]])
     extends ClientCall.Listener[Response] {
   override def onMessage(message: Response): Unit = {
     request(1)
@@ -20,14 +18,14 @@ class Fs2StreamClientCallListener[Response](request: Int => Unit,
     queue.enqueue1(GrpcStatus(status, trailers).asLeft).unsafeRunSync()
   }
 
-  def stream[F[_]](implicit F: LiftIO[F]): Stream[F, Response] = {
+  def stream[F[_]: RaiseThrowable](implicit F: LiftIO[F]): Stream[F, Response] = {
     def go(q: Stream[F, Either[GrpcStatus, Response]]): Pull[F, Response, Unit] = {
       // TODO: Write in terms of Segment
       q.pull.uncons1.flatMap {
         case Some((Right(v), tl)) => Pull.output1(v) >> go(tl)
         case Some((Left(GrpcStatus(status, trailers)), _)) =>
           if (!status.isOk)
-            Pull.raiseError(status.asRuntimeException(trailers))
+            Pull.raiseError[F](status.asRuntimeException(trailers))
           else
             Pull.done
         case None => Pull.done
@@ -39,11 +37,11 @@ class Fs2StreamClientCallListener[Response](request: Int => Unit,
 }
 
 object Fs2StreamClientCallListener {
-  def apply[F[_], Response](request: Int => Unit)(implicit F: LiftIO[F],
-                                                  ec: ExecutionContext): F[Fs2StreamClientCallListener[Response]] = {
+  def apply[F[_], Response](request: Int => Unit)(implicit F: Concurrent[F],
+                                                  cs: ContextShift[IO]): F[Fs2StreamClientCallListener[Response]] = {
     F.liftIO(
-      fs2.async
-        .unboundedQueue[IO, Either[GrpcStatus, Response]]
+      Queue
+        .unbounded[IO, Either[GrpcStatus, Response]]
         .map(new Fs2StreamClientCallListener[Response](request, _)))
   }
 }

--- a/java-runtime/src/main/scala/server/Fs2ServerCallHandler.scala
+++ b/java-runtime/src/main/scala/server/Fs2ServerCallHandler.scala
@@ -1,16 +1,14 @@
 package org.lyranthe.fs2_grpc.java_runtime.server
 
-import cats.effect.Effect
+import cats.effect._
 import cats.implicits._
 import fs2._
 import io.grpc._
 
-import scala.concurrent.ExecutionContext
-
 class Fs2ServerCallHandler[F[_]](val dummy: Boolean = false) extends AnyVal {
   def unaryToUnaryCall[Request, Response](implementation: (Request, Metadata) => F[Response])(
-      implicit F: Effect[F],
-      ec: ExecutionContext): ServerCallHandler[Request, Response] =
+      implicit F: ConcurrentEffect[F],
+      cs: ContextShift[IO]): ServerCallHandler[Request, Response] =
     new ServerCallHandler[Request, Response] {
       def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
         val listener = Fs2UnaryServerCallListener[F].unsafeCreate(call)
@@ -22,8 +20,8 @@ class Fs2ServerCallHandler[F[_]](val dummy: Boolean = false) extends AnyVal {
     }
 
   def unaryToStreamingCall[Request, Response](implementation: (Request, Metadata) => Stream[F, Response])(
-      implicit F: Effect[F],
-      ec: ExecutionContext): ServerCallHandler[Request, Response] =
+      implicit F: ConcurrentEffect[F],
+      cs: ContextShift[IO]): ServerCallHandler[Request, Response] =
     new ServerCallHandler[Request, Response] {
       def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
         val listener = Fs2UnaryServerCallListener[F].unsafeCreate(call)
@@ -37,8 +35,8 @@ class Fs2ServerCallHandler[F[_]](val dummy: Boolean = false) extends AnyVal {
     }
 
   def streamingToUnaryCall[Request, Response](implementation: (Stream[F, Request], Metadata) => F[Response])(
-      implicit F: Effect[F],
-      ec: ExecutionContext): ServerCallHandler[Request, Response] =
+      implicit F: ConcurrentEffect[F],
+      cs: ContextShift[IO]): ServerCallHandler[Request, Response] =
     new ServerCallHandler[Request, Response] {
       def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
         val listener = Fs2StreamServerCallListener[F].unsafeCreate(call)
@@ -49,8 +47,8 @@ class Fs2ServerCallHandler[F[_]](val dummy: Boolean = false) extends AnyVal {
 
   def streamingToStreamingCall[Request, Response](
       implementation: (Stream[F, Request], Metadata) => Stream[F, Response])(
-      implicit F: Effect[F],
-      ec: ExecutionContext): ServerCallHandler[Request, Response] =
+      implicit F: ConcurrentEffect[F],
+      cs: ContextShift[IO]): ServerCallHandler[Request, Response] =
     new ServerCallHandler[Request, Response] {
       def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
         val listener = Fs2StreamServerCallListener[F].unsafeCreate(call)

--- a/java-runtime/src/main/scala/syntax/AllSyntax.scala
+++ b/java-runtime/src/main/scala/syntax/AllSyntax.scala
@@ -1,5 +1,3 @@
 package org.lyranthe.fs2_grpc.java_runtime.syntax
 
-trait AllSyntax
-    extends ManagedChannelBuilderSyntax
-    with ServerBuilderSyntax
+trait AllSyntax extends ManagedChannelBuilderSyntax with ServerBuilderSyntax

--- a/java-runtime/src/main/scala/syntax/ManagedChannelBuilderSyntax.scala
+++ b/java-runtime/src/main/scala/syntax/ManagedChannelBuilderSyntax.scala
@@ -1,18 +1,17 @@
 package org.lyranthe.fs2_grpc.java_runtime.syntax
 
 import cats.effect._
+import fs2.Stream
 import io.grpc.{ManagedChannel, ManagedChannelBuilder}
 import java.util.concurrent.TimeUnit
-import fs2._
 import scala.concurrent._
 
 trait ManagedChannelBuilderSyntax {
-  implicit final def fs2GrpcSyntaxManagedChannelBuilder[A <: ManagedChannelBuilder[A]](
-      builder: ManagedChannelBuilder[A]): ManagedChannelBuilderOps[A] = new ManagedChannelBuilderOps[A](builder)
+  implicit final def fs2GrpcSyntaxManagedChannelBuilder(builder: ManagedChannelBuilder[_]): ManagedChannelBuilderOps =
+    new ManagedChannelBuilderOps(builder)
 }
 
-final class ManagedChannelBuilderOps[A <: ManagedChannelBuilder[A]](val builder: ManagedChannelBuilder[A])
-    extends AnyVal {
+final class ManagedChannelBuilderOps(val builder: ManagedChannelBuilder[_]) extends AnyVal {
 
   /**
     * Builds a `ManagedChannel` into a bracketed stream. The managed channel is
@@ -23,10 +22,10 @@ final class ManagedChannelBuilderOps[A <: ManagedChannelBuilder[A]](val builder:
     * 2. We block for up to 30 seconds on termination, using the blocking context
     * 3. If the channel is not yet terminated, we trigger a forceful shutdown
     *
-    * For different tradeoffs in shutdown behavior, see {{streamWithShutdown}}.
+    * For different tradeoffs in shutdown behavior, see {{resourceWithShutdown}}.
     */
-  def stream[F[_]](implicit F: Sync[F]): Stream[F, ManagedChannel] =
-    streamWithShutdown { ch =>
+  def resource[F[_]](implicit F: Sync[F]): Resource[F, ManagedChannel] =
+    resourceWithShutdown { ch =>
       F.delay {
         ch.shutdown()
         if (!blocking(ch.awaitTermination(30, TimeUnit.SECONDS))) {
@@ -37,6 +36,33 @@ final class ManagedChannelBuilderOps[A <: ManagedChannelBuilder[A]](val builder:
     }
 
   /**
+    * Builds a `ManagedChannel` into a bracketed resource. The managed channel is
+    * shut down when the resource is released.
+    *
+    * @param shutdown Determines the behavior of the cleanup of the managed
+    * channel, with respect to forceful vs. graceful shutdown and how to poll
+    * or block for termination.
+    */
+  def resourceWithShutdown[F[_]](shutdown: ManagedChannel => F[Unit])(
+      implicit F: Sync[F]): Resource[F, ManagedChannel] =
+    Resource.make(F.delay(builder.build()))(shutdown)
+
+  /**
+    * Builds a `ManagedChannel` into a bracketed stream. The managed channel is
+    * shut down when the resource is released.  Shutdown is as follows:
+    *
+    * 1. We request an orderly shutdown, allowing preexisting calls to continue
+    *    without accepting new calls.
+    * 2. We block for up to 30 seconds on termination, using the blocking context
+    * 3. If the channel is not yet terminated, we trigger a forceful shutdown
+    *
+    * For different tradeoffs in shutdown behavior, see {{streamWithShutdown}}.
+    */
+  @deprecated("Use resource", "0.4.0")
+  def stream[F[_]](implicit F: Sync[F]): Stream[F, ManagedChannel] =
+    Stream.resource(resource[F])
+
+  /**
     * Builds a `ManagedChannel` into a bracketed stream. The managed channel is
     * shut down when the stream is complete.
     *
@@ -44,6 +70,7 @@ final class ManagedChannelBuilderOps[A <: ManagedChannelBuilder[A]](val builder:
     * channel, with respect to forceful vs. graceful shutdown and how to poll
     * or block for termination.
     */
+  @deprecated("Use resourceWithShutdown", "0.4.0")
   def streamWithShutdown[F[_]](shutdown: ManagedChannel => F[Unit])(implicit F: Sync[F]): Stream[F, ManagedChannel] =
-    Stream.bracket(F.delay(builder.build()))(Stream.emit[ManagedChannel], channel => shutdown(channel))
+    Stream.resource(resourceWithShutdown(shutdown))
 }

--- a/java-runtime/src/main/scala/syntax/ServerBuilderSyntax.scala
+++ b/java-runtime/src/main/scala/syntax/ServerBuilderSyntax.scala
@@ -1,18 +1,50 @@
 package org.lyranthe.fs2_grpc.java_runtime.syntax
 
 import cats.effect._
+import fs2.Stream
 import io.grpc.{Server, ServerBuilder}
 import java.util.concurrent.TimeUnit
-import fs2._
 import scala.concurrent._
 
 trait ServerBuilderSyntax {
-  implicit final def fs2GrpcSyntaxServerBuilder[A <: ServerBuilder[A]](
-      builder: ServerBuilder[A]): ServerBuilderOps[A] = new ServerBuilderOps[A](builder)
+  implicit final def fs2GrpcSyntaxServerBuilder(builder: ServerBuilder[_]): ServerBuilderOps =
+    new ServerBuilderOps(builder)
 }
 
-final class ServerBuilderOps[A <: ServerBuilder[A]](val builder: ServerBuilder[A])
-    extends AnyVal {
+final class ServerBuilderOps(val builder: ServerBuilder[_]) extends AnyVal {
+
+  /**
+    * Builds a `Server` into a bracketed resource. The server is shut
+    * down when the resource is released. Shutdown is as follows:
+    *
+    * 1. We request an orderly shutdown, allowing preexisting calls to continue
+    *    without accepting new calls.
+    * 2. We block for up to 30 seconds on termination, using the blocking context
+    * 3. If the server is not yet terminated, we trigger a forceful shutdown
+    *
+    * For different tradeoffs in shutdown behavior, see {{resourceWithShutdown}}.
+    */
+  def resource[F[_]](implicit F: Sync[F]): Resource[F, Server] =
+    resourceWithShutdown { server =>
+      F.delay {
+        server.shutdown()
+        if (!blocking(server.awaitTermination(30, TimeUnit.SECONDS))) {
+          server.shutdownNow()
+          ()
+        }
+      }
+    }
+
+  /**
+    * Builds a `Server` into a bracketed resource. The server is shut
+    * down when the resource is released.
+    *
+    * @param shutdown Determines the behavior of the cleanup of the
+    * server, with respect to forceful vs. graceful shutdown and how
+    * to poll or block for termination.
+    */
+  def resourceWithShutdown[F[_]](shutdown: Server => F[Unit])(implicit F: Sync[F]): Resource[F, Server] =
+    Resource.make(F.delay(builder.build()))(shutdown)
 
   /**
     * Builds a `Server` into a bracketed stream. The server is shut
@@ -25,16 +57,9 @@ final class ServerBuilderOps[A <: ServerBuilder[A]](val builder: ServerBuilder[A
     *
     * For different tradeoffs in shutdown behavior, see {{streamWithShutdown}}.
     */
+  @deprecated("Use resource", "0.4.0")
   def stream[F[_]](implicit F: Sync[F]): Stream[F, Server] =
-    streamWithShutdown { server =>
-      F.delay {
-        server.shutdown()
-        if (!blocking(server.awaitTermination(30, TimeUnit.SECONDS))) {
-          server.shutdownNow()
-          ()
-        }
-      }
-    }
+    Stream.resource(resource[F])
 
   /**
     * Builds a `Server` into a bracketed stream. The server is shut
@@ -44,6 +69,7 @@ final class ServerBuilderOps[A <: ServerBuilder[A]](val builder: ServerBuilder[A
     * server, with respect to forceful vs. graceful shutdown and how
     * to poll or block for termination.
     */
+  @deprecated("Use resourceWithShutdown", "0.4.0")
   def streamWithShutdown[F[_]](shutdown: Server => F[Unit])(implicit F: Sync[F]): Stream[F, Server] =
-    Stream.bracket(F.delay(builder.build()))(Stream.emit[Server], server => shutdown(server))
+    Stream.resource(resourceWithShutdown(shutdown))
 }

--- a/java-runtime/src/main/scala/syntax/package.scala
+++ b/java-runtime/src/main/scala/syntax/package.scala
@@ -1,7 +1,7 @@
 package org.lyranthe.fs2_grpc.java_runtime
 
 package object syntax {
-  object all extends AllSyntax
+  object all                   extends AllSyntax
   object managedChannelBuilder extends ManagedChannelBuilderSyntax
-  object serverBuilder extends ServerBuilderSyntax  
+  object serverBuilder         extends ServerBuilderSyntax
 }

--- a/java-runtime/src/test/scala/client/ClientSuite.scala
+++ b/java-runtime/src/test/scala/client/ClientSuite.scala
@@ -12,6 +12,7 @@ import scala.util.Success
 object ClientSuite extends SimpleTestSuite {
   test("single message to unaryToUnary") {
     implicit val ec = TestContext()
+    implicit val cs = IO.contextShift(ec)
 
     val dummy  = new DummyClientCall()
     val client = new Fs2ClientCall[IO, String, Int](dummy)
@@ -33,6 +34,7 @@ object ClientSuite extends SimpleTestSuite {
 
   test("no response message to unaryToUnary") {
     implicit val ec = TestContext()
+    implicit val cs = IO.contextShift(ec)
 
     val dummy  = new DummyClientCall()
     val client = new Fs2ClientCall[IO, String, Int](dummy)
@@ -51,6 +53,7 @@ object ClientSuite extends SimpleTestSuite {
 
   test("error response to unaryToUnary") {
     implicit val ec = TestContext()
+    implicit val cs = IO.contextShift(ec)
 
     val dummy  = new DummyClientCall()
     val client = new Fs2ClientCall[IO, String, Int](dummy)
@@ -74,6 +77,7 @@ object ClientSuite extends SimpleTestSuite {
 
   test("stream to streamingToUnary") {
     implicit val ec = TestContext()
+    implicit val cs = IO.contextShift(ec)
 
     val dummy  = new DummyClientCall()
     val client = new Fs2ClientCall[IO, String, Int](dummy)
@@ -98,6 +102,7 @@ object ClientSuite extends SimpleTestSuite {
 
   test("0-length to streamingToUnary") {
     implicit val ec = TestContext()
+    implicit val cs = IO.contextShift(ec)
 
     val dummy  = new DummyClientCall()
     val client = new Fs2ClientCall[IO, String, Int](dummy)
@@ -122,6 +127,7 @@ object ClientSuite extends SimpleTestSuite {
 
   test("single message to unaryToStreaming") {
     implicit val ec = TestContext()
+    implicit val cs = IO.contextShift(ec)
 
     val dummy  = new DummyClientCall()
     val client = new Fs2ClientCall[IO, String, Int](dummy)
@@ -146,6 +152,7 @@ object ClientSuite extends SimpleTestSuite {
 
   test("stream to streamingToStreaming") {
     implicit val ec = TestContext()
+    implicit val cs = IO.contextShift(ec)
 
     val dummy  = new DummyClientCall()
     val client = new Fs2ClientCall[IO, String, Int](dummy)
@@ -174,6 +181,7 @@ object ClientSuite extends SimpleTestSuite {
 
   test("error returned from streamingToStreaming") {
     implicit val ec = TestContext()
+    implicit val cs = IO.contextShift(ec)
 
     val dummy  = new DummyClientCall()
     val client = new Fs2ClientCall[IO, String, Int](dummy)
@@ -206,14 +214,14 @@ object ClientSuite extends SimpleTestSuite {
     assertEquals(dummy.requested, 4)
   }
 
-  test("stream awaits termination of managed channel") {
+  test("resource awaits termination of managed channel") {
     implicit val ec = TestContext()
 
     import implicits._
-    val result = ManagedChannelBuilder.forAddress("127.0.0.1", 0).stream[IO].compile.last.unsafeToFuture()
+    val result = ManagedChannelBuilder.forAddress("127.0.0.1", 0).resource[IO].use(IO.pure).unsafeToFuture()
 
     ec.tick()
-    val channel = result.value.get.get.get
+    val channel = result.value.get.get
     assert(channel.isTerminated)
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.5
+sbt.version=1.2.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,4 +10,4 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.3")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.0"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.1"

--- a/sbt-java-gen/src/main/scala/GrpcServicePrinter.scala
+++ b/sbt-java-gen/src/main/scala/GrpcServicePrinter.scala
@@ -6,18 +6,22 @@ import scalapb.compiler.{DescriptorImplicits, FunctionalPrinter, StreamType}
 
 class Fs2GrpcServicePrinter(service: ServiceDescriptor, di: DescriptorImplicits){
   import di._
+  import Fs2GrpcServicePrinter.constants._
+
+  private[this] val serviceName: String    = service.name
+  private[this] val servicePkgName: String = service.getFile.scalaPackageName
 
   private[this] def serviceMethodSignature(method: MethodDescriptor) = {
 
     val scalaInType   = method.inputType.scalaType
     val scalaOutType  = method.outputType.scalaType
-    val clientHeaders = "clientHeaders: _root_.io.grpc.Metadata"
+    val clientHeaders = s"clientHeaders: $Metadata"
 
     s"def ${method.name}" + (method.streamType match {
       case StreamType.Unary           => s"(request: $scalaInType, $clientHeaders): F[$scalaOutType]"
-      case StreamType.ClientStreaming => s"(request: _root_.fs2.Stream[F, $scalaInType], $clientHeaders): F[$scalaOutType]"
-      case StreamType.ServerStreaming => s"(request: $scalaInType, $clientHeaders): _root_.fs2.Stream[F, $scalaOutType]"
-      case StreamType.Bidirectional   => s"(request: _root_.fs2.Stream[F, $scalaInType], $clientHeaders): _root_.fs2.Stream[F, $scalaOutType]"
+      case StreamType.ClientStreaming => s"(request: $Stream[F, $scalaInType], $clientHeaders): F[$scalaOutType]"
+      case StreamType.ServerStreaming => s"(request: $scalaInType, $clientHeaders): $Stream[F, $scalaOutType]"
+      case StreamType.Bidirectional   => s"(request: $Stream[F, $scalaInType], $clientHeaders): $Stream[F, $scalaOutType]"
     })
   }
 
@@ -32,9 +36,9 @@ class Fs2GrpcServicePrinter(service: ServiceDescriptor, di: DescriptorImplicits)
 
   private[this] def createClientCall(method: MethodDescriptor) = {
     val basicClientCall =
-      s"_root_.org.lyranthe.fs2_grpc.java_runtime.client.Fs2ClientCall[F](channel, _root_.${service.getFile.scalaPackageName}.${service.name}Grpc.${method.descriptorName}, callOptions)"
+      s"$Fs2ClientCall[F](channel, _root_.$servicePkgName.${serviceName}Grpc.${method.descriptorName}, callOptions)"
     if (method.isServerStreaming)
-      s"_root_.fs2.Stream.eval($basicClientCall)"
+      s"$Stream.eval($basicClientCall)"
     else
       basicClientCall
   }
@@ -52,7 +56,7 @@ class Fs2GrpcServicePrinter(service: ServiceDescriptor, di: DescriptorImplicits)
   // TODO: update this
   private[this] def serviceBindingImplementation(method: MethodDescriptor): PrinterEndo = { p =>
     p.add(
-      s".addMethod(_root_.${service.getFile.scalaPackageName}.${service.getName}Grpc.${method.descriptorName}, _root_.org.lyranthe.fs2_grpc.java_runtime.server.Fs2ServerCallHandler[F].${handleMethod(
+      s".addMethod(_root_.$servicePkgName.${serviceName}Grpc.${method.descriptorName}, $Fs2ServerCallHandler[F].${handleMethod(
         method)}(serviceImpl.${method.name}))")
   }
 
@@ -63,20 +67,20 @@ class Fs2GrpcServicePrinter(service: ServiceDescriptor, di: DescriptorImplicits)
 
   private[this] def serviceBindingImplementations: PrinterEndo =
     _.indent
-      .add(s".builder(_root_.${service.getFile.scalaPackageName}.${service.getName}Grpc.${service.descriptorName})")
+      .add(s".builder(_root_.$servicePkgName.${serviceName}Grpc.${service.descriptorName})")
       .call(service.methods.map(serviceBindingImplementation): _*)
       .add(".build()")
       .outdent
 
   private[this] def serviceTrait: PrinterEndo =
-    _.add(s"trait ${service.name}Fs2Grpc[F[_]] {").indent.call(serviceMethods).outdent.add("}")
+    _.add(s"trait ${serviceName}Fs2Grpc[F[_]] {").indent.call(serviceMethods).outdent.add("}")
 
   private[this] def serviceObject: PrinterEndo =
-    _.add(s"object ${service.name}Fs2Grpc {").indent.call(serviceClient).call(serviceBinding).outdent.add("}")
+    _.add(s"object ${serviceName}Fs2Grpc {").indent.call(serviceClient).call(serviceBinding).outdent.add("}")
 
   private[this] def serviceClient: PrinterEndo = {
     _.add(
-      s"def stub[F[_]: _root_.cats.effect.Effect](channel: _root_.io.grpc.Channel, callOptions: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT)(implicit ec: _root_.scala.concurrent.ExecutionContext): ${service.name}Fs2Grpc[F] = new ${service.name}Fs2Grpc[F] {").indent
+      s"def stub[F[_]: $ConcurrentEffect](channel: $Channel, callOptions: $CallOptions = $CallOptions.DEFAULT)(implicit cs: $ContextShiftIO): ${serviceName}Fs2Grpc[F] = new ${serviceName}Fs2Grpc[F] {").indent
       .call(serviceMethodImplementations)
       .outdent
       .add("}")
@@ -84,8 +88,8 @@ class Fs2GrpcServicePrinter(service: ServiceDescriptor, di: DescriptorImplicits)
 
   private[this] def serviceBinding: PrinterEndo = {
     _.add(
-      s"def bindService[F[_]: _root_.cats.effect.Effect](serviceImpl: ${service.name}Fs2Grpc[F])(implicit ec: _root_.scala.concurrent.ExecutionContext): _root_.io.grpc.ServerServiceDefinition = {").indent
-      .add("_root_.io.grpc.ServerServiceDefinition")
+      s"def bindService[F[_]: $ConcurrentEffect](serviceImpl: ${service.name}Fs2Grpc[F])(implicit cs: $ContextShiftIO): $ServerServiceDefinition = {").indent
+      .add(s"$ServerServiceDefinition")
       .call(serviceBindingImplementations)
       .outdent
       .add("}")
@@ -93,8 +97,35 @@ class Fs2GrpcServicePrinter(service: ServiceDescriptor, di: DescriptorImplicits)
 
   def printService(printer: FunctionalPrinter): FunctionalPrinter = {
     printer
-      .add("package " + service.getFile.scalaPackageName, "", "import _root_.cats.implicits._", "")
+      .add(s"package $servicePkgName", "", "import _root_.cats.implicits._", "")
       .call(serviceTrait)
       .call(serviceObject)
   }
+}
+
+object Fs2GrpcServicePrinter {
+
+  object constants {
+
+    private val effPkg  = "_root_.cats.effect"
+    private val grpcPkg = "_root_.io.grpc"
+    private val jrtPkg  = "_root_.org.lyranthe.fs2_grpc.java_runtime"
+    private val fs2Pkg  = "_root_.fs2"
+
+    ///
+
+    val ContextShiftIO          = s"$effPkg.ContextShift[$effPkg.IO]"
+    val ConcurrentEffect        = s"$effPkg.ConcurrentEffect"
+
+    val Stream                  = s"$fs2Pkg.Stream"
+    val Fs2ServerCallHandler    = s"$jrtPkg.server.Fs2ServerCallHandler"
+    val Fs2ClientCall           = s"$jrtPkg.client.Fs2ClientCall"
+
+    val ServerServiceDefinition = s"$grpcPkg.ServerServiceDefinition"
+    val CallOptions             = s"$grpcPkg.CallOptions"
+    val Channel                 = s"$grpcPkg.Channel"
+    val Metadata                = s"$grpcPkg.Metadata"
+
+  }
+
 }


### PR DESCRIPTION
 - adjust grpc service printer to use fs2 1.0 based
   code.

 - make grpc service printer easier to read by introducing
   constants for common types used in signatures.

 - upgrade dependencies.