### PR TITLE
fs2 1.0: adjustments to runtime & codegen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: scala
 scala:
    - 2.11.12
-   - 2.12.6
+   - 2.12.7
 jdk:
   - oraclejdk8
-  - oraclejdk10
+  - openjdk11
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test

--- a/build.sbt
+++ b/build.sbt
@@ -43,18 +43,18 @@ lazy val `sbt-java-gen` = project
 lazy val `java-runtime` = project
   .enablePlugins(GitVersioning)
   .settings(
-    scalaVersion := "2.12.6",
+    scalaVersion := "2.12.7",
     crossScalaVersions := List(scalaVersion.value, "2.11.12"),
     publishTo := sonatypePublishTo.value,
     libraryDependencies ++= List(
-      "co.fs2"        %% "fs2-core"         % "0.10.5",
-      "org.typelevel" %% "cats-effect"      % "0.10.1",
-      "org.typelevel" %% "cats-effect-laws" % "0.10.1" % "test",
+      "co.fs2"        %% "fs2-core"         % "1.0.0",
+      "org.typelevel" %% "cats-effect"      % "1.0.0",
+      "org.typelevel" %% "cats-effect-laws" % "1.0.0" % "test",
       "io.grpc"       % "grpc-core"         % scalapb.compiler.Version.grpcJavaVersion,
       "io.grpc"       % "grpc-netty-shaded" % scalapb.compiler.Version.grpcJavaVersion % "test",
-      "io.monix"      %% "minitest"         % "2.1.1" % "test"
+      "io.monix"      %% "minitest"         % "2.2.1" % "test"
     ),
     mimaPreviousArtifacts := Set(organization.value %% name.value % "0.3.0"),
     testFrameworks += new TestFramework("minitest.runner.Framework"),
-    addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.7" cross CrossVersion.binary)
+    addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.8" cross CrossVersion.binary)
   )

--- a/java-runtime/src/main/scala/client/Fs2ClientCall.scala
+++ b/java-runtime/src/main/scala/client/Fs2ClientCall.scala
@@ -1,14 +1,14 @@
-package org.lyranthe.fs2_grpc.java_runtime.client
+package org.lyranthe.fs2_grpc
+package java_runtime
+package client
 
 import cats.effect._
 import cats.implicits._
 import io.grpc.{Metadata, _}
 import fs2._
 
-import scala.concurrent.ExecutionContext
-
-case class UnaryResult[A](value: Option[A], status: Option[GrpcStatus])
-case class GrpcStatus(status: Status, trailers: Metadata)
+final case class UnaryResult[A](value: Option[A], status: Option[GrpcStatus])
+final case class GrpcStatus(status: Status, trailers: Metadata)
 
 class Fs2ClientCall[F[_], Request, Response] private[client] (val call: ClientCall[Request, Response]) extends AnyVal {
 
@@ -24,8 +24,7 @@ class Fs2ClientCall[F[_], Request, Response] private[client] (val call: ClientCa
   private def start(listener: ClientCall.Listener[Response], metadata: Metadata)(implicit F: Sync[F]): F[Unit] =
     F.delay(call.start(listener, metadata))
 
-  def startListener[A <: ClientCall.Listener[Response]](createListener: F[A], headers: Metadata)(
-      implicit F: Sync[F]): F[A] = {
+  def startListener[A <: ClientCall.Listener[Response]](createListener: F[A], headers: Metadata)(implicit F: Sync[F]): F[A] = {
     createListener.flatTap(start(_, headers)) <* request(1)
   }
 
@@ -37,47 +36,48 @@ class Fs2ClientCall[F[_], Request, Response] private[client] (val call: ClientCa
     stream.evalMap(sendMessage) ++ Stream.eval(halfClose)
   }
 
-  def unaryToUnaryCall(message: Request, headers: Metadata)(implicit F: Async[F], ec: ExecutionContext): F[Response] = {
+  def unaryToUnaryCall(message: Request, headers: Metadata)(implicit F: ConcurrentEffect[F]): F[Response] = {
     for {
       listener <- startListener(Fs2UnaryClientCallListener[F, Response], headers)
       _        <- sendSingleMessage(message)
-      result   <- listener.getValue[F]
+      result   <- listener.getValue
     } yield result
   }
 
-  def streamingToUnaryCall(messages: Stream[F, Request], headers: Metadata)(implicit F: Effect[F],
-                                                                            ec: ExecutionContext): F[Response] = {
+  def streamingToUnaryCall(messages: Stream[F, Request], headers: Metadata)(implicit F: ConcurrentEffect[F]): F[Response] = {
     for {
       listener <- startListener(Fs2UnaryClientCallListener[F, Response], headers)
       result   <- Stream.eval(listener.getValue).concurrently(sendStream(messages)).compile.last
     } yield result.get
   }
 
-  def unaryToStreamingCall(message: Request, headers: Metadata)(implicit F: Async[F],
-                                                                ec: ExecutionContext): Stream[F, Response] = {
+  def unaryToStreamingCall(message: Request, headers: Metadata)(implicit F: ConcurrentEffect[F]): Stream[F, Response] = {
     for {
       listener <- Stream.eval(
         startListener(Fs2StreamClientCallListener[F, Response](call.request), headers) <* sendSingleMessage(message))
-      result <- listener.stream[F]
+      result <- listener.stream
     } yield result
   }
 
   def streamingToStreamingCall(messages: Stream[F, Request],
-                               headers: Metadata)(implicit F: Effect[F], ec: ExecutionContext): Stream[F, Response] = {
+                               headers: Metadata)(implicit F: ConcurrentEffect[F]): Stream[F, Response] = {
     for {
       listener      <- Stream.eval(startListener(Fs2StreamClientCallListener[F, Response](call.request), headers))
-      resultOrError <- listener.stream[F].concurrently(sendStream(messages))
+      resultOrError <- listener.stream.concurrently(sendStream(messages))
     } yield resultOrError
   }
 }
 
 object Fs2ClientCall {
+
   class PartiallyAppliedClientCall[F[_]](val dummy: Boolean = false) extends AnyVal {
+
     def apply[Request, Response](
         channel: Channel,
         methodDescriptor: MethodDescriptor[Request, Response],
         callOptions: CallOptions)(implicit F: Sync[F]): F[Fs2ClientCall[F, Request, Response]] =
       F.delay(new Fs2ClientCall(channel.newCall[Request, Response](methodDescriptor, callOptions)))
+
   }
 
   def apply[F[_]]: PartiallyAppliedClientCall[F] =

--- a/java-runtime/src/main/scala/client/Fs2UnaryClientCallListener.scala
+++ b/java-runtime/src/main/scala/client/Fs2UnaryClientCallListener.scala
@@ -1,50 +1,51 @@
-package org.lyranthe.fs2_grpc.java_runtime.client
+package org.lyranthe.fs2_grpc
+package java_runtime
+package client
 
-import cats.effect.{IO, LiftIO}
+import cats.effect._
+import cats.effect.concurrent.{Deferred, Ref}
 import cats.implicits._
 import io.grpc._
 
-import scala.concurrent.ExecutionContext
+class Fs2UnaryClientCallListener[F[_], Response](
+  grpcStatus: Deferred[F, GrpcStatus],
+  value: Ref[F, Option[Response]])(implicit F: Effect[F]) extends ClientCall.Listener[Response] {
 
-class Fs2UnaryClientCallListener[Response](grpcStatus: fs2.async.Promise[IO, GrpcStatus],
-                                           value: fs2.async.Ref[IO, Option[Response]])
-    extends ClientCall.Listener[Response] {
   override def onClose(status: Status, trailers: Metadata): Unit =
-    grpcStatus.complete(GrpcStatus(status, trailers)).unsafeRunSync()
+    grpcStatus.complete(GrpcStatus(status, trailers)).unsafeRun()
 
   override def onMessage(message: Response): Unit =
-    value.setAsync(message.some).unsafeRunSync()
+    value.set(message.some).unsafeRun()
 
-  def getValue[F[_]](implicit F: LiftIO[F]): F[Response] = {
-    val result: IO[Response] = for {
+  def getValue: F[Response] = {
+     for {
       r <- grpcStatus.get
       v <- value.get
       result <- {
         if (!r.status.isOk)
-          IO.raiseError(r.status.asRuntimeException(r.trailers))
+          F.raiseError(r.status.asRuntimeException(r.trailers))
         else {
           v match {
             case None =>
-              IO.raiseError(
+              F.raiseError(
                 Status.INTERNAL
                   .withDescription("No value received for unary call")
                   .asRuntimeException(r.trailers))
             case Some(v1) =>
-              IO.pure(v1)
+              F.pure(v1)
           }
         }
       }
     } yield result
-
-    F.liftIO(result)
   }
 }
 
 object Fs2UnaryClientCallListener {
-  def apply[F[_], Response](implicit F: LiftIO[F], ec: ExecutionContext): F[Fs2UnaryClientCallListener[Response]] = {
-    F.liftIO(for {
-      response <- fs2.async.promise[IO, GrpcStatus]
-      value    <- fs2.async.refOf[IO, Option[Response]](None)
-    } yield new Fs2UnaryClientCallListener[Response](response, value))
+
+  def apply[F[_]: ConcurrentEffect, Response]: F[Fs2UnaryClientCallListener[F, Response]] = {
+    (Deferred[F, GrpcStatus], Ref.of[F, Option[Response]](none)).mapN((response, value) =>
+      new Fs2UnaryClientCallListener[F, Response](response, value)
+    )
   }
+
 }

--- a/java-runtime/src/main/scala/implicits.scala
+++ b/java-runtime/src/main/scala/implicits.scala
@@ -1,3 +1,4 @@
-package org.lyranthe.fs2_grpc.java_runtime
+package org.lyranthe.fs2_grpc
+package java_runtime
 
 object implicits extends syntax.AllSyntax

--- a/java-runtime/src/main/scala/java_runtime.scala
+++ b/java-runtime/src/main/scala/java_runtime.scala
@@ -1,0 +1,11 @@
+package org.lyranthe.fs2_grpc
+
+import cats.effect.Effect
+
+package object java_runtime {
+
+  private[java_runtime] implicit class EffectOps[F[_]: Effect, T](f: F[T]) {
+    def unsafeRun(): T = Effect[F].toIO(f).unsafeRunSync()
+  }
+
+}

--- a/java-runtime/src/main/scala/server/Fs2ServerCall.scala
+++ b/java-runtime/src/main/scala/server/Fs2ServerCall.scala
@@ -1,4 +1,6 @@
-package org.lyranthe.fs2_grpc.java_runtime.server
+package org.lyranthe.fs2_grpc
+package java_runtime
+package server
 
 import cats.effect._
 import io.grpc._

--- a/java-runtime/src/main/scala/server/Fs2ServerCallHandler.scala
+++ b/java-runtime/src/main/scala/server/Fs2ServerCallHandler.scala
@@ -1,47 +1,40 @@
-package org.lyranthe.fs2_grpc.java_runtime.server
+package org.lyranthe.fs2_grpc
+package java_runtime
+package server
 
-import cats.effect.Effect
+import cats.effect._
 import cats.implicits._
 import fs2._
 import io.grpc._
 
-import scala.concurrent.ExecutionContext
-
 class Fs2ServerCallHandler[F[_]](val dummy: Boolean = false) extends AnyVal {
+
   def unaryToUnaryCall[Request, Response](implementation: (Request, Metadata) => F[Response])(
-      implicit F: Effect[F],
-      ec: ExecutionContext): ServerCallHandler[Request, Response] =
+      implicit F: ConcurrentEffect[F]): ServerCallHandler[Request, Response] =
     new ServerCallHandler[Request, Response] {
       def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
-        val listener = Fs2UnaryServerCallListener[F].unsafeCreate(call)
-        listener.unsafeUnaryResponse(headers, _ flatMap { request =>
-          implementation(request, headers)
-        })
+        val listener = Fs2UnaryServerCallListener[F](call).unsafeRun()
+        listener.unsafeUnaryResponse(headers, _ flatMap { request => implementation(request, headers) })
         listener
       }
     }
 
   def unaryToStreamingCall[Request, Response](implementation: (Request, Metadata) => Stream[F, Response])(
-      implicit F: Effect[F],
-      ec: ExecutionContext): ServerCallHandler[Request, Response] =
+      implicit F: ConcurrentEffect[F]): ServerCallHandler[Request, Response] =
     new ServerCallHandler[Request, Response] {
       def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
-        val listener = Fs2UnaryServerCallListener[F].unsafeCreate(call)
-        listener.unsafeStreamResponse(new Metadata(),
-                                      v =>
-                                        Stream.eval(v) flatMap { request =>
-                                          implementation(request, headers)
-                                      })
+        val listener = Fs2UnaryServerCallListener[F](call).unsafeRun()
+        listener.unsafeStreamResponse(
+          new Metadata(), v => Stream.eval(v) flatMap { request => implementation(request, headers) })
         listener
       }
     }
 
   def streamingToUnaryCall[Request, Response](implementation: (Stream[F, Request], Metadata) => F[Response])(
-      implicit F: Effect[F],
-      ec: ExecutionContext): ServerCallHandler[Request, Response] =
+      implicit F: ConcurrentEffect[F]): ServerCallHandler[Request, Response] =
     new ServerCallHandler[Request, Response] {
       def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
-        val listener = Fs2StreamServerCallListener[F].unsafeCreate(call)
+        val listener = Fs2StreamServerCallListener[F](call).unsafeRun()
         listener.unsafeUnaryResponse(headers, implementation(_, headers))
         listener
       }
@@ -49,11 +42,10 @@ class Fs2ServerCallHandler[F[_]](val dummy: Boolean = false) extends AnyVal {
 
   def streamingToStreamingCall[Request, Response](
       implementation: (Stream[F, Request], Metadata) => Stream[F, Response])(
-      implicit F: Effect[F],
-      ec: ExecutionContext): ServerCallHandler[Request, Response] =
+      implicit F: ConcurrentEffect[F]): ServerCallHandler[Request, Response] =
     new ServerCallHandler[Request, Response] {
       def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
-        val listener = Fs2StreamServerCallListener[F].unsafeCreate(call)
+        val listener = Fs2StreamServerCallListener[F](call).unsafeRun()
         listener.unsafeStreamResponse(headers, implementation(_, headers))
         listener
       }

--- a/java-runtime/src/main/scala/server/Fs2ServerCallListener.scala
+++ b/java-runtime/src/main/scala/server/Fs2ServerCallListener.scala
@@ -1,6 +1,8 @@
-package org.lyranthe.fs2_grpc.java_runtime.server
+package org.lyranthe.fs2_grpc
+package java_runtime
+package server
 
-import cats.effect.{Effect, IO, Sync}
+import cats.effect.{Sync, Effect, IO}
 import cats.implicits._
 import fs2.Stream
 import io.grpc.{Metadata, Status, StatusException, StatusRuntimeException}
@@ -9,7 +11,7 @@ private[server] trait Fs2ServerCallListener[F[_], G[_], Request, Response] {
   def source: G[Request]
   def call: Fs2ServerCall[F, Request, Response]
 
-  def reportError(t: Throwable)(implicit F: Sync[F]): F[Unit] = {
+  private def reportError(t: Throwable)(implicit F: Sync[F]): F[Unit] = {
     t match {
       case ex: StatusException =>
         call.closeStream(ex.getStatus, Option(ex.getTrailers).getOrElse(new Metadata()))
@@ -21,24 +23,23 @@ private[server] trait Fs2ServerCallListener[F[_], G[_], Request, Response] {
     }
   }
 
-  def handleUnaryResponse(headers: Metadata, response: F[Response])(implicit F: Sync[F]): F[Unit] = {
+  private def handleUnaryResponse(headers: Metadata, response: F[Response])(implicit F: Sync[F]): F[Unit] = {
     ((call.sendHeaders(headers) *> call.request(1) *> response >>= call.sendMessage) *>
       call.closeStream(Status.OK, new Metadata()))
       .handleErrorWith(reportError)
   }
 
-  def handleStreamResponse(headers: Metadata, response: Stream[F, Response])(implicit F: Sync[F]): F[Unit] =
+  private def handleStreamResponse(headers: Metadata, response: Stream[F, Response])(implicit F: Sync[F]): F[Unit] =
     (call.sendHeaders(headers) *> call.request(1) *>
       (response.evalMap(call.sendMessage) ++ Stream.eval(call.closeStream(Status.OK, new Metadata()))).compile.drain)
       .handleErrorWith(reportError)
 
-  def unsafeRun(f: F[Unit])(implicit F: Effect[F]): Unit =
+  private def unsafeRun(f: F[Unit])(implicit F: Effect[F]): Unit =
     F.runAsync(f)(_.fold(IO.raiseError, _ => IO.unit)).unsafeRunSync()
 
   def unsafeUnaryResponse(headers: Metadata, implementation: G[Request] => F[Response])(implicit F: Effect[F]): Unit =
     unsafeRun(handleUnaryResponse(headers, implementation(source)))
 
-  def unsafeStreamResponse(headers: Metadata, implementation: G[Request] => Stream[F, Response])(
-      implicit F: Effect[F]): Unit =
+  def unsafeStreamResponse(headers: Metadata, implementation: G[Request] => Stream[F, Response])(implicit F: Effect[F]): Unit =
     unsafeRun(handleStreamResponse(headers, implementation(source)))
 }

--- a/java-runtime/src/main/scala/server/Fs2StreamServerCallListener.scala
+++ b/java-runtime/src/main/scala/server/Fs2StreamServerCallListener.scala
@@ -1,38 +1,38 @@
-package org.lyranthe.fs2_grpc.java_runtime.server
+package org.lyranthe.fs2_grpc
+package java_runtime
+package server
 
-import cats.arrow.FunctionK
-import cats.effect._
+import cats.effect.{ConcurrentEffect, Effect}
 import cats.implicits._
-import io.grpc._
+import io.grpc.ServerCall
+import fs2.concurrent.Queue
 import fs2._
 
-import scala.concurrent.ExecutionContext
-
 class Fs2StreamServerCallListener[F[_], Request, Response] private (
-    queue: async.mutable.Queue[IO, Option[Request]],
+    queue: Queue[F, Option[Request]],
     val call: Fs2ServerCall[F, Request, Response])(implicit F: Effect[F])
     extends ServerCall.Listener[Request]
     with Fs2ServerCallListener[F, Stream[F, ?], Request, Response] {
+
   override def onMessage(message: Request): Unit = {
     call.call.request(1)
-    queue.enqueue1(message.some).unsafeRunSync()
+    queue.enqueue1(message.some).unsafeRun()
   }
 
-  override def onHalfClose(): Unit = queue.enqueue1(none).unsafeRunSync()
+  override def onHalfClose(): Unit = queue.enqueue1(none).unsafeRun()
 
   override def source: Stream[F, Request] =
-    queue.dequeue.unNoneTerminate.translate(FunctionK.lift(F.liftIO _))
+    queue.dequeue.unNoneTerminate
 }
 
 object Fs2StreamServerCallListener {
   class PartialFs2StreamServerCallListener[F[_]](val dummy: Boolean = false) extends AnyVal {
-    def unsafeCreate[Request, Response](call: ServerCall[Request, Response])(
-        implicit F: Effect[F],
-        ec: ExecutionContext): Fs2StreamServerCallListener[F, Request, Response] = {
-      async
-        .unboundedQueue[IO, Option[Request]]
-        .map(new Fs2StreamServerCallListener[F, Request, Response](_, Fs2ServerCall[F, Request, Response](call)))
-        .unsafeRunSync()
+
+    def apply[Request, Response](call: ServerCall[Request, Response])(
+      implicit F: ConcurrentEffect[F]
+    ): F[Fs2StreamServerCallListener[F, Request, Response]] = {
+      Queue.unbounded[F, Option[Request]].
+        map(new Fs2StreamServerCallListener[F, Request, Response](_, Fs2ServerCall[F, Request, Response](call)))
     }
   }
 

--- a/java-runtime/src/main/scala/syntax/AllSyntax.scala
+++ b/java-runtime/src/main/scala/syntax/AllSyntax.scala
@@ -1,4 +1,6 @@
-package org.lyranthe.fs2_grpc.java_runtime.syntax
+package org.lyranthe.fs2_grpc
+package java_runtime
+package syntax
 
 trait AllSyntax
     extends ManagedChannelBuilderSyntax

--- a/java-runtime/src/main/scala/syntax/ManagedChannelBuilderSyntax.scala
+++ b/java-runtime/src/main/scala/syntax/ManagedChannelBuilderSyntax.scala
@@ -1,18 +1,19 @@
-package org.lyranthe.fs2_grpc.java_runtime.syntax
+package org.lyranthe.fs2_grpc
+package java_runtime
+package syntax
 
 import cats.effect._
+import fs2.Stream
 import io.grpc.{ManagedChannel, ManagedChannelBuilder}
 import java.util.concurrent.TimeUnit
-import fs2._
 import scala.concurrent._
 
 trait ManagedChannelBuilderSyntax {
-  implicit final def fs2GrpcSyntaxManagedChannelBuilder[A <: ManagedChannelBuilder[A]](
-      builder: ManagedChannelBuilder[A]): ManagedChannelBuilderOps[A] = new ManagedChannelBuilderOps[A](builder)
+  implicit final def fs2GrpcSyntaxManagedChannelBuilder(builder: ManagedChannelBuilder[_]): ManagedChannelBuilderOps =
+    new ManagedChannelBuilderOps(builder)
 }
 
-final class ManagedChannelBuilderOps[A <: ManagedChannelBuilder[A]](val builder: ManagedChannelBuilder[A])
-    extends AnyVal {
+final class ManagedChannelBuilderOps(val builder: ManagedChannelBuilder[_]) extends AnyVal {
 
   /**
     * Builds a `ManagedChannel` into a bracketed stream. The managed channel is
@@ -23,10 +24,10 @@ final class ManagedChannelBuilderOps[A <: ManagedChannelBuilder[A]](val builder:
     * 2. We block for up to 30 seconds on termination, using the blocking context
     * 3. If the channel is not yet terminated, we trigger a forceful shutdown
     *
-    * For different tradeoffs in shutdown behavior, see {{streamWithShutdown}}.
+    * For different tradeoffs in shutdown behavior, see {{resourceWithShutdown}}.
     */
-  def stream[F[_]](implicit F: Sync[F]): Stream[F, ManagedChannel] =
-    streamWithShutdown { ch =>
+  def resource[F[_]](implicit F: Sync[F]): Resource[F, ManagedChannel] =
+    resourceWithShutdown { ch =>
       F.delay {
         ch.shutdown()
         if (!blocking(ch.awaitTermination(30, TimeUnit.SECONDS))) {
@@ -37,6 +38,32 @@ final class ManagedChannelBuilderOps[A <: ManagedChannelBuilder[A]](val builder:
     }
 
   /**
+    * Builds a `ManagedChannel` into a bracketed resource. The managed channel is
+    * shut down when the resource is released.
+    *
+    * @param shutdown Determines the behavior of the cleanup of the managed
+    * channel, with respect to forceful vs. graceful shutdown and how to poll
+    * or block for termination.
+    */
+  def resourceWithShutdown[F[_]](shutdown: ManagedChannel => F[Unit])(
+      implicit F: Sync[F]): Resource[F, ManagedChannel] =
+    Resource.make(F.delay(builder.build()))(shutdown)
+
+  /**
+    * Builds a `ManagedChannel` into a bracketed stream. The managed channel is
+    * shut down when the resource is released.  Shutdown is as follows:
+    *
+    * 1. We request an orderly shutdown, allowing preexisting calls to continue
+    *    without accepting new calls.
+    * 2. We block for up to 30 seconds on termination, using the blocking context
+    * 3. If the channel is not yet terminated, we trigger a forceful shutdown
+    *
+    * For different tradeoffs in shutdown behavior, see {{streamWithShutdown}}.
+    */
+  def stream[F[_]](implicit F: Sync[F]): Stream[F, ManagedChannel] =
+    Stream.resource(resource[F])
+
+  /**
     * Builds a `ManagedChannel` into a bracketed stream. The managed channel is
     * shut down when the stream is complete.
     *
@@ -45,5 +72,5 @@ final class ManagedChannelBuilderOps[A <: ManagedChannelBuilder[A]](val builder:
     * or block for termination.
     */
   def streamWithShutdown[F[_]](shutdown: ManagedChannel => F[Unit])(implicit F: Sync[F]): Stream[F, ManagedChannel] =
-    Stream.bracket(F.delay(builder.build()))(Stream.emit[ManagedChannel], channel => shutdown(channel))
+    Stream.resource(resourceWithShutdown(shutdown))
 }

--- a/java-runtime/src/main/scala/syntax/ServerBuilderSyntax.scala
+++ b/java-runtime/src/main/scala/syntax/ServerBuilderSyntax.scala
@@ -1,18 +1,52 @@
-package org.lyranthe.fs2_grpc.java_runtime.syntax
+package org.lyranthe.fs2_grpc
+package java_runtime
+package syntax
 
 import cats.effect._
+import fs2.Stream
 import io.grpc.{Server, ServerBuilder}
 import java.util.concurrent.TimeUnit
-import fs2._
 import scala.concurrent._
 
 trait ServerBuilderSyntax {
-  implicit final def fs2GrpcSyntaxServerBuilder[A <: ServerBuilder[A]](
-      builder: ServerBuilder[A]): ServerBuilderOps[A] = new ServerBuilderOps[A](builder)
+  implicit final def fs2GrpcSyntaxServerBuilder(builder: ServerBuilder[_]): ServerBuilderOps =
+    new ServerBuilderOps(builder)
 }
 
-final class ServerBuilderOps[A <: ServerBuilder[A]](val builder: ServerBuilder[A])
-    extends AnyVal {
+final class ServerBuilderOps(val builder: ServerBuilder[_]) extends AnyVal {
+
+  /**
+    * Builds a `Server` into a bracketed resource. The server is shut
+    * down when the resource is released. Shutdown is as follows:
+    *
+    * 1. We request an orderly shutdown, allowing preexisting calls to continue
+    *    without accepting new calls.
+    * 2. We block for up to 30 seconds on termination, using the blocking context
+    * 3. If the server is not yet terminated, we trigger a forceful shutdown
+    *
+    * For different tradeoffs in shutdown behavior, see {{resourceWithShutdown}}.
+    */
+  def resource[F[_]](implicit F: Sync[F]): Resource[F, Server] =
+    resourceWithShutdown { server =>
+      F.delay {
+        server.shutdown()
+        if (!blocking(server.awaitTermination(30, TimeUnit.SECONDS))) {
+          server.shutdownNow()
+          ()
+        }
+      }
+    }
+
+  /**
+    * Builds a `Server` into a bracketed resource. The server is shut
+    * down when the resource is released.
+    *
+    * @param shutdown Determines the behavior of the cleanup of the
+    * server, with respect to forceful vs. graceful shutdown and how
+    * to poll or block for termination.
+    */
+  def resourceWithShutdown[F[_]](shutdown: Server => F[Unit])(implicit F: Sync[F]): Resource[F, Server] =
+    Resource.make(F.delay(builder.build()))(shutdown)
 
   /**
     * Builds a `Server` into a bracketed stream. The server is shut
@@ -26,15 +60,7 @@ final class ServerBuilderOps[A <: ServerBuilder[A]](val builder: ServerBuilder[A
     * For different tradeoffs in shutdown behavior, see {{streamWithShutdown}}.
     */
   def stream[F[_]](implicit F: Sync[F]): Stream[F, Server] =
-    streamWithShutdown { server =>
-      F.delay {
-        server.shutdown()
-        if (!blocking(server.awaitTermination(30, TimeUnit.SECONDS))) {
-          server.shutdownNow()
-          ()
-        }
-      }
-    }
+    Stream.resource(resource[F])
 
   /**
     * Builds a `Server` into a bracketed stream. The server is shut
@@ -45,5 +71,5 @@ final class ServerBuilderOps[A <: ServerBuilder[A]](val builder: ServerBuilder[A
     * to poll or block for termination.
     */
   def streamWithShutdown[F[_]](shutdown: Server => F[Unit])(implicit F: Sync[F]): Stream[F, Server] =
-    Stream.bracket(F.delay(builder.build()))(Stream.emit[Server], server => shutdown(server))
+    Stream.resource(resourceWithShutdown(shutdown))
 }

--- a/java-runtime/src/main/scala/syntax/package.scala
+++ b/java-runtime/src/main/scala/syntax/package.scala
@@ -1,4 +1,5 @@
-package org.lyranthe.fs2_grpc.java_runtime
+package org.lyranthe.fs2_grpc
+package java_runtime
 
 package object syntax {
   object all extends AllSyntax

--- a/java-runtime/src/test/scala/client/DummyClientCall.scala
+++ b/java-runtime/src/test/scala/client/DummyClientCall.scala
@@ -1,8 +1,9 @@
-package org.lyranthe.fs2_grpc.java_runtime.client
-
-import io.grpc._
+package org.lyranthe.fs2_grpc
+package java_runtime
+package client
 
 import scala.collection.mutable.ArrayBuffer
+import io.grpc._
 
 class DummyClientCall extends ClientCall[String, Int] {
   var requested: Int = 0

--- a/java-runtime/src/test/scala/server/ServerSuite.scala
+++ b/java-runtime/src/test/scala/server/ServerSuite.scala
@@ -1,21 +1,25 @@
-package org.lyranthe.fs2_grpc.java_runtime
+package org.lyranthe.fs2_grpc
+package java_runtime
 package server
 
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.effect.laws.util.TestContext
-//import cats.implicits._
-//import fs2._
+import cats.implicits._
+import fs2._
 import io.grpc._
 import minitest._
 
 object ServerSuite extends SimpleTestSuite {
-  test("single message to unaryToUnary") {
-    implicit val ec = TestContext()
-    val dummy = new DummyServerCall
-    val listener = Fs2UnaryServerCallListener[IO].unsafeCreate(dummy)
 
-    listener
-      .unsafeUnaryResponse(new Metadata(), _.map(_.length))
+  test("single message to unaryToUnary") {
+
+    implicit val ec: TestContext      = TestContext()
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
+
+    val dummy    = new DummyServerCall
+    val listener = Fs2UnaryServerCallListener[IO](dummy).unsafeRunSync()
+
+    listener.unsafeUnaryResponse(new Metadata(), _.map(_.length))
     listener.onMessage("123")
     listener.onHalfClose()
 
@@ -28,9 +32,12 @@ object ServerSuite extends SimpleTestSuite {
   }
 
   test("multiple messages to unaryToUnary") {
-    implicit val ec = TestContext()
-    val dummy = new DummyServerCall
-    val listener = Fs2UnaryServerCallListener[IO].unsafeCreate(dummy)
+
+    implicit val ec: TestContext      = TestContext()
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
+
+    val dummy    = new DummyServerCall
+    val listener = Fs2UnaryServerCallListener[IO](dummy).unsafeRunSync()
 
     listener.unsafeUnaryResponse(new Metadata(), _.map(_.length))
     listener.onMessage("123")
@@ -44,115 +51,124 @@ object ServerSuite extends SimpleTestSuite {
     ec.tick()
 
     assertEquals(dummy.currentStatus.isDefined, true)
-    assertResult(true,
-                 "Current status true because stream completed successfully")(
-      dummy.currentStatus.get.isOk)
+    assertResult(true, "Current status true because stream completed successfully")(dummy.currentStatus.get.isOk)
   }
 
-  test("stream awaits termination of server") {
-    implicit val ec = TestContext()
+  test("resource awaits termination of server") {
 
+    implicit val ec: TestContext = TestContext()
     import implicits._
-    val result = ServerBuilder.forPort(0).stream[IO].compile.last.unsafeToFuture()
 
+    val result = ServerBuilder.forPort(0).resource[IO].use(IO.pure).unsafeToFuture()
     ec.tick()
-    val server = result.value.get.get.get
+    val server = result.value.get.get
     assert(server.isTerminated)
   }
-  
-//  test("single message to unaryToStreaming") {
-//    val dummy = new DummyServerCall
-//
-//    val serverCall = new Fs2ServerCall[IO, String, Int](dummy)
-//    val listener = serverCall
-//      .unaryToStreamingCall(new Metadata(),
-//                            s =>
-//                              Stream
-//                                .emit(s.length)
-//                                .repeat
-//                                .take(5))
-//      .unsafeRunSync()
-//    listener.onMessage("123")
-//    listener.onHalfClose()
-//    Thread.sleep(200)
-//    assertEquals(dummy.messages.size, 5)
-//    assertEquals(dummy.messages(0), 3)
-//    assertEquals(dummy.currentStatus.isDefined, true)
-//    assertEquals(dummy.currentStatus.get.isOk, true)
-//  }
-//
-//  test("zero messages to streamingToStreaming") {
-//    val dummy = new DummyServerCall
-//
-//    val serverCall = new Fs2ServerCall[IO, String, Int](dummy)
-//    val listener = serverCall
-//      .streamingToStreamingCall(new Metadata(),
-//                                s => Stream.emit(3).repeat.take(5))
-//      .unsafeRunSync()
-//    listener.onHalfClose()
-//    Thread.sleep(200)
-//    assertEquals(dummy.messages.size, 5)
-//    assertEquals(dummy.messages(0), 3)
-//    assertEquals(dummy.currentStatus.isDefined, true)
-//    assertEquals(dummy.currentStatus.get.isOk, true)
-//  }
-//
-//  test("messages to streamingToStreaming") {
-//    val dummy = new DummyServerCall
-//
-//    val serverCall = new Fs2ServerCall[IO, String, Int](dummy)
-//    val listener = serverCall
-//      .streamingToStreamingCall(new Metadata(), _.map(_.length).intersperse(0))
-//      .unsafeRunSync()
-//    listener.onMessage("a")
-//    listener.onMessage("ab")
-//    listener.onHalfClose()
-//    Thread.sleep(400)
-//    assertEquals(dummy.messages.length, 3)
-//    assertEquals(dummy.messages.toList, List(1, 0, 2))
-//    assertEquals(dummy.currentStatus.isDefined, true)
-//    assertEquals(dummy.currentStatus.get.isOk, true)
-//  }
-//
-//  test("messages to streamingToStreaming") {
-//    val dummy = new DummyServerCall
-//
-//    val serverCall = new Fs2ServerCall[IO, String, Int](dummy)
-//    val listener = serverCall
-//      .streamingToStreamingCall(new Metadata(),
-//                                _.map(_.length) ++ Stream.emit(0) ++ Stream
-//                                  .raiseError(new RuntimeException("hello")))
-//      .unsafeRunSync()
-//    listener.onMessage("a")
-//    listener.onMessage("ab")
-//    listener.onHalfClose()
-//    listener.onMessage("abc")
-//    Thread.sleep(400)
-//    assertEquals(dummy.messages.length, 3)
-//    assertEquals(dummy.messages.toList, List(1, 2, 0))
-//    assertEquals(dummy.currentStatus.isDefined, true)
-//    assertEquals(dummy.currentStatus.get.isOk, false)
-//  }
-//
-//  test("streaming to unary") {
-//    val implementation: Stream[IO, String] => IO[Int] =
-//      _.compile.foldMonoid.map(_.length)
-//
-//    val dummy = new DummyServerCall
-//    val serverCall = new Fs2ServerCall[IO, String, Int](dummy)
-//    val listener =
-//      serverCall
-//        .streamingToUnaryCall(new Metadata(), implementation)
-//        .unsafeRunSync()
-//
-//    listener.onMessage("ab")
-//    listener.onMessage("abc")
-//    listener.onHalfClose()
-//    Thread.sleep(100)
-//    assertEquals(dummy.messages.length, 1)
-//    assertEquals(dummy.messages(0), 5)
-//    assertEquals(dummy.currentStatus.isDefined, true)
-//    assertEquals(dummy.currentStatus.get.isOk, true)
-//  }
+
+  test("single message to unaryToStreaming") {
+
+    implicit val ec: TestContext      = TestContext()
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
+
+    val dummy = new DummyServerCall
+    val listener = Fs2UnaryServerCallListener[IO].apply[String, Int](dummy).unsafeRunSync()
+
+    listener.unsafeStreamResponse(new Metadata(), s => Stream.eval(s).map(_.length).repeat.take(5))
+    listener.onMessage("123")
+    listener.onHalfClose()
+
+    ec.tick()
+
+    assertEquals(dummy.messages.size, 5)
+    assertEquals(dummy.messages(0), 3)
+    assertEquals(dummy.currentStatus.isDefined, true)
+    assertEquals(dummy.currentStatus.get.isOk, true)
+  }
+
+  test("zero messages to streamingToStreaming") {
+
+    implicit val ec: TestContext      = TestContext()
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
+
+    val dummy = new DummyServerCall
+    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy).unsafeRunSync()
+
+    listener.unsafeStreamResponse(new Metadata(), _ => Stream.emit(3).repeat.take(5))
+    listener.onHalfClose()
+
+    ec.tick()
+
+    assertEquals(dummy.messages.size, 5)
+    assertEquals(dummy.messages(0), 3)
+    assertEquals(dummy.currentStatus.isDefined, true)
+    assertEquals(dummy.currentStatus.get.isOk, true)
+  }
+
+  test("messages to streamingToStreaming") {
+
+    implicit val ec: TestContext      = TestContext()
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
+
+    val dummy = new DummyServerCall
+    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy).unsafeRunSync()
+
+    listener.unsafeStreamResponse(new Metadata(), _.map(_.length).intersperse(0))
+    listener.onMessage("a")
+    listener.onMessage("ab")
+    listener.onHalfClose()
+
+    ec.tick()
+
+    assertEquals(dummy.messages.length, 3)
+    assertEquals(dummy.messages.toList, List(1, 0, 2))
+    assertEquals(dummy.currentStatus.isDefined, true)
+    assertEquals(dummy.currentStatus.get.isOk, true)
+  }
+
+  test("messages to streamingToStreaming") {
+
+    implicit val ec: TestContext      = TestContext()
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
+
+    val dummy = new DummyServerCall
+    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy).unsafeRunSync()
+
+    listener.unsafeStreamResponse(new Metadata(), _.map(_.length) ++ Stream.emit(0) ++ Stream.raiseError[IO](new RuntimeException("hello")))
+    listener.onMessage("a")
+    listener.onMessage("ab")
+    listener.onHalfClose()
+    listener.onMessage("abc")
+
+    ec.tick()
+
+    assertEquals(dummy.messages.length, 3)
+    assertEquals(dummy.messages.toList, List(1, 2, 0))
+    assertEquals(dummy.currentStatus.isDefined, true)
+    assertEquals(dummy.currentStatus.get.isOk, false)
+  }
+
+  test("streaming to unary") {
+
+    implicit val ec: TestContext      = TestContext()
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
+
+    val implementation: Stream[IO, String] => IO[Int] =
+      _.compile.foldMonoid.map(_.length)
+
+    val dummy = new DummyServerCall
+    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy).unsafeRunSync()
+
+    listener.unsafeUnaryResponse(new Metadata(), implementation)
+    listener.onMessage("ab")
+    listener.onMessage("abc")
+    listener.onHalfClose()
+
+    ec.tick()
+
+    assertEquals(dummy.messages.length, 1)
+    assertEquals(dummy.messages(0), 5)
+    assertEquals(dummy.currentStatus.isDefined, true)
+    assertEquals(dummy.currentStatus.get.isOk, true)
+  }
 
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.5
+sbt.version=1.2.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype" % "2.3")
 addSbtPlugin("com.jsuereth"     % "sbt-pgp"      % "1.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git"      % "1.0.0")
@@ -10,4 +11,4 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.3")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.0"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.1"


### PR DESCRIPTION
- adjust client and server based code to operate
   in terms of type classes instead of `IO`.

 - fix server suite tests that were commented.

 - adjust grpc service printer to use fs2 1.0 based
   code.

 - make grpc service printer easier to read by introducing
   constants for common types used in signatures.

 - change travis from oraclejdk10 to openjdk11 and
   bump scala.

 - add sbt-coursier for faster artifact fetching

 - upgrade dependencies.