### PR TITLE
Cancellation support for cats-effect

### DIFF
--- a/java-runtime/src/main/scala/server/Fs2StreamServerCallListener.scala
+++ b/java-runtime/src/main/scala/server/Fs2StreamServerCallListener.scala
@@ -2,6 +2,7 @@ package org.lyranthe.fs2_grpc
 package java_runtime
 package server
 
+import cats.effect.concurrent.Deferred
 import cats.effect.{ConcurrentEffect, Effect}
 import cats.implicits._
 import io.grpc.ServerCall
@@ -9,31 +10,40 @@ import fs2.concurrent.Queue
 import fs2._
 
 class Fs2StreamServerCallListener[F[_], Request, Response] private (
-    queue: Queue[F, Option[Request]],
+    requestQ: Queue[F, Option[Request]],
+    val isCancelled: Deferred[F, Unit],
     val call: Fs2ServerCall[F, Request, Response])(implicit F: Effect[F])
     extends ServerCall.Listener[Request]
     with Fs2ServerCallListener[F, Stream[F, ?], Request, Response] {
 
-  override def onMessage(message: Request): Unit = {
-    call.call.request(1)
-    queue.enqueue1(message.some).unsafeRun()
+  override def onCancel(): Unit = {
+    isCancelled.complete(()).unsafeRun()
   }
 
-  override def onHalfClose(): Unit = queue.enqueue1(none).unsafeRun()
+  override def onMessage(message: Request): Unit = {
+    call.call.request(1)
+    requestQ.enqueue1(message.some).unsafeRun()
+  }
+
+  override def onHalfClose(): Unit = requestQ.enqueue1(none).unsafeRun()
 
   override def source: Stream[F, Request] =
-    queue.dequeue.unNoneTerminate
+    requestQ.dequeue.unNoneTerminate
 }
 
 object Fs2StreamServerCallListener {
   class PartialFs2StreamServerCallListener[F[_]](val dummy: Boolean = false) extends AnyVal {
 
     def apply[Request, Response](call: ServerCall[Request, Response])(
-      implicit F: ConcurrentEffect[F]
-    ): F[Fs2StreamServerCallListener[F, Request, Response]] = {
-      Queue.unbounded[F, Option[Request]].
-        map(new Fs2StreamServerCallListener[F, Request, Response](_, Fs2ServerCall[F, Request, Response](call)))
-    }
+        implicit F: ConcurrentEffect[F]
+    ): F[Fs2StreamServerCallListener[F, Request, Response]] =
+      for {
+        inputQ      <- Queue.unbounded[F, Option[Request]]
+        isCancelled <- Deferred[F, Unit]
+      } yield
+        new Fs2StreamServerCallListener[F, Request, Response](inputQ,
+                                                              isCancelled,
+                                                              Fs2ServerCall[F, Request, Response](call))
   }
 
   def apply[F[_]] = new PartialFs2StreamServerCallListener[F]

--- a/java-runtime/src/test/scala/client/DummyClientCall.scala
+++ b/java-runtime/src/test/scala/client/DummyClientCall.scala
@@ -6,17 +6,18 @@ import scala.collection.mutable.ArrayBuffer
 import io.grpc._
 
 class DummyClientCall extends ClientCall[String, Int] {
-  var requested: Int = 0
-  val messagesSent: ArrayBuffer[String] = ArrayBuffer[String]()
+  var requested: Int                             = 0
+  val messagesSent: ArrayBuffer[String]          = ArrayBuffer[String]()
   var listener: Option[ClientCall.Listener[Int]] = None
+  var cancelled: Option[(String, Throwable)]     = None
 
-  override def start(responseListener: ClientCall.Listener[Int],
-                     headers: Metadata): Unit =
+  override def start(responseListener: ClientCall.Listener[Int], headers: Metadata): Unit =
     listener = Some(responseListener)
 
   override def request(numMessages: Int): Unit = requested += numMessages
 
-  override def cancel(message: String, cause: Throwable): Unit = ()
+  override def cancel(message: String, cause: Throwable): Unit =
+    cancelled = Some((message, cause))
 
   override def halfClose(): Unit = ()
 

--- a/java-runtime/src/test/scala/server/DummyServerCall.scala
+++ b/java-runtime/src/test/scala/server/DummyServerCall.scala
@@ -5,11 +5,10 @@ import io.grpc.{Metadata, MethodDescriptor, ServerCall, Status}
 import scala.collection.mutable.ArrayBuffer
 
 class DummyServerCall extends ServerCall[String, Int] {
-  val messages: ArrayBuffer[Int] = ArrayBuffer[Int]()
+  val messages: ArrayBuffer[Int]    = ArrayBuffer[Int]()
   var currentStatus: Option[Status] = None
 
   override def request(numMessages: Int): Unit = ()
-  override def isCancelled: Boolean = false
   override def sendMessage(message: Int): Unit = {
     messages += message
     ()
@@ -21,4 +20,5 @@ class DummyServerCall extends ServerCall[String, Int] {
   override def close(status: Status, trailers: Metadata): Unit = {
     currentStatus = Some(status)
   }
+  override def isCancelled: Boolean = false
 }


### PR DESCRIPTION
 - If client call is cancelled, it will send a cancellation message to the server
 - If client processing fails while streaming, it will send a cancellation
     message to the server
 - If cancellation is signalled, Server will attempt to cancel ongoing processing
     (via effect cancelation), and respond with status CANCELLED.

Fixes #4 