### PR TITLE
generator: fix missing file descriptors

### DIFF
--- a/sbt-java-gen/src/main/scala/Fs2GrpcPlugin.scala
+++ b/sbt-java-gen/src/main/scala/Fs2GrpcPlugin.scala
@@ -47,8 +47,8 @@ object Fs2CodeGenerator extends ProtocCodeGenerator {
                 acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps.toArray))
             }
 
+          val implicits = new DescriptorImplicits(params, filesByName.values.toVector)
           val genFiles  = request.getFileToGenerateList.asScala.map(filesByName)
-          val implicits = new DescriptorImplicits(params, genFiles)
           val srvFiles  = genFiles.flatMap(generateServiceFiles(_, implicits))
           b.addAllFile(srvFiles.asJava)
         } catch {


### PR DESCRIPTION
 - fix missing file descriptors. The list of
   file descriptors handed to `DescriptorImplicits`
   should come from `getProtoFileList` and not
   `getFileToGenerateList` as a service might use
   types that are not generated.

   Note: This is the same approach that ScalaPB itself
         uses when populating `DescriptorImplicits` with
         file descriptors.