### PR TITLE
Extract Fs2CodeGenerator into java-gen project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,15 +29,28 @@ lazy val root = project.in(file("."))
   )
   .aggregate(`sbt-java-gen`, `java-runtime`)
 
-lazy val `sbt-java-gen` = project
+lazy val `java-gen` = project
   .enablePlugins(GitVersioning, BuildInfoPlugin)
+  .settings(
+    scalaVersion := "2.12.8",
+    crossScalaVersions := List(scalaVersion.value, "2.11.12", "2.13.0-M5"),
+    publishTo := sonatypePublishTo.value,
+    buildInfoPackage := "org.lyranthe.fs2_grpc.buildinfo",
+    libraryDependencies ++= List(
+      "com.thesamet.scalapb" %% "protoc-bridge"  % "0.7.6",
+      "com.thesamet.scalapb" %% "compilerplugin" % scalapb.compiler.Version.scalapbVersion,
+    )
+  )
+
+lazy val `sbt-java-gen` = project
+  .dependsOn(`java-gen`)
+  .enablePlugins(GitVersioning)
   .settings(
     publishTo := sonatypePublishTo.value,
     sbtPlugin := true,
     crossSbtVersions := List(sbtVersion.value, "0.13.18"),
     buildInfoPackage := "org.lyranthe.fs2_grpc.buildinfo",
     addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.21"),
-    libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % scalapb.compiler.Version.scalapbVersion
   )
 
 lazy val `java-runtime` = project

--- a/java-gen/src/main/scala/Fs2CodeGenerator.scala
+++ b/java-gen/src/main/scala/Fs2CodeGenerator.scala
@@ -1,0 +1,69 @@
+package org.lyranthe.fs2_grpc.java_gen
+
+import com.google.protobuf.Descriptors.FileDescriptor
+import com.google.protobuf.ExtensionRegistry
+import com.google.protobuf.compiler.PluginProtos
+import com.google.protobuf.compiler.PluginProtos.{CodeGeneratorRequest, CodeGeneratorResponse}
+import protocbridge.{Artifact, ProtocCodeGenerator}
+import scala.collection.JavaConverters._
+import scalapb.compiler.{FunctionalPrinter, GeneratorException, DescriptorImplicits, ProtobufGenerator}
+import scalapb.options.compiler.Scalapb
+
+class Fs2CodeGenerator(serviceSuffix: String) extends ProtocCodeGenerator {
+
+  def generateServiceFiles(file: FileDescriptor,
+                           di: DescriptorImplicits): Seq[PluginProtos.CodeGeneratorResponse.File] = {
+    file.getServices.asScala.map { service =>
+      val p = new Fs2GrpcServicePrinter(service, serviceSuffix, di)
+
+      import di.{ServiceDescriptorPimp, FileDescriptorPimp}
+      val code = p.printService(FunctionalPrinter()).result()
+      val b    = CodeGeneratorResponse.File.newBuilder()
+      b.setName(file.scalaDirectory + "/" + service.name + s"$serviceSuffix.scala")
+      b.setContent(code)
+      println(b.getName)
+      b.build
+    }
+  }
+
+  def handleCodeGeneratorRequest(request: PluginProtos.CodeGeneratorRequest): PluginProtos.CodeGeneratorResponse = {
+    val b = CodeGeneratorResponse.newBuilder
+    ProtobufGenerator.parseParameters(request.getParameter) match {
+      case Right(params) =>
+        try {
+
+          val filesByName: Map[String, FileDescriptor] =
+            request.getProtoFileList.asScala.foldLeft[Map[String, FileDescriptor]](Map.empty) {
+              case (acc, fp) =>
+                val deps = fp.getDependencyList.asScala.map(acc)
+                acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps.toArray))
+            }
+
+          val implicits = new DescriptorImplicits(params, filesByName.values.toVector)
+          val genFiles  = request.getFileToGenerateList.asScala.map(filesByName)
+          val srvFiles  = genFiles.flatMap(generateServiceFiles(_, implicits))
+          b.addAllFile(srvFiles.asJava)
+        } catch {
+          case e: GeneratorException =>
+            b.setError(e.message)
+        }
+
+      case Left(error) =>
+        b.setError(error)
+    }
+
+    b.build()
+  }
+
+  override def run(req: Array[Byte]): Array[Byte] = {
+    println("Running")
+    val registry = ExtensionRegistry.newInstance()
+    Scalapb.registerAllExtensions(registry)
+    val request = CodeGeneratorRequest.parseFrom(req, registry)
+    handleCodeGeneratorRequest(request).toByteArray
+  }
+
+  override def suggestedDependencies: Seq[Artifact] = Seq(
+    Artifact("com.thesamet.scalapb", "scalapb-runtime", scalapb.compiler.Version.scalapbVersion, crossVersion = true)
+  )
+}

--- a/java-gen/src/main/scala/Fs2GrpcServicePrinter.scala
+++ b/java-gen/src/main/scala/Fs2GrpcServicePrinter.scala
@@ -1,0 +1,183 @@
+package org.lyranthe.fs2_grpc.java_gen
+
+import com.google.protobuf.Descriptors.{MethodDescriptor, ServiceDescriptor}
+import scalapb.compiler.FunctionalPrinter.PrinterEndo
+import scalapb.compiler.{DescriptorImplicits, FunctionalPrinter, StreamType}
+
+class Fs2GrpcServicePrinter(service: ServiceDescriptor, serviceSuffix: String, di: DescriptorImplicits){
+  import di._
+  import Fs2GrpcServicePrinter.constants._
+
+  private[this] val serviceName: String    = service.name
+  private[this] val serviceNameFs2: String = s"$serviceName$serviceSuffix"
+  private[this] val servicePkgName: String = service.getFile.scalaPackageName
+
+  private[this] def serviceMethodSignature(method: MethodDescriptor) = {
+
+    val scalaInType   = method.inputType.scalaType
+    val scalaOutType  = method.outputType.scalaType
+    val ctx           = s"ctx: $Ctx"
+
+    s"def ${method.name}" + (method.streamType match {
+      case StreamType.Unary           => s"(request: $scalaInType, $ctx): F[$scalaOutType]"
+      case StreamType.ClientStreaming => s"(request: $Stream[F, $scalaInType], $ctx): F[$scalaOutType]"
+      case StreamType.ServerStreaming => s"(request: $scalaInType, $ctx): $Stream[F, $scalaOutType]"
+      case StreamType.Bidirectional   => s"(request: $Stream[F, $scalaInType], $ctx): $Stream[F, $scalaOutType]"
+    })
+  }
+
+  private[this] def handleMethod(method: MethodDescriptor) = {
+    method.streamType match {
+      case StreamType.Unary           => "unaryToUnaryCall"
+      case StreamType.ClientStreaming => "streamingToUnaryCall"
+      case StreamType.ServerStreaming => "unaryToStreamingCall"
+      case StreamType.Bidirectional   => "streamingToStreamingCall"
+    }
+  }
+
+  private[this] def createClientCall(method: MethodDescriptor) = {
+    val basicClientCall =
+      s"$Fs2ClientCall[F](channel, _root_.$servicePkgName.${serviceName}Grpc.${method.descriptorName}, c($CallOptions.DEFAULT))"
+    if (method.isServerStreaming)
+      s"$Stream.eval($basicClientCall)"
+    else
+      basicClientCall
+  }
+
+  private[this] def serviceMethodImplementation(method: MethodDescriptor): PrinterEndo = { p =>
+    p.add(serviceMethodSignature(method) + " = {")
+      .indent
+      .add(
+        s"${createClientCall(method)}.flatMap(_.${handleMethod(method)}(request, f(ctx)))"
+      )
+      .outdent
+      .add("}")
+  }
+
+  private[this] def serviceBindingImplementation(method: MethodDescriptor): PrinterEndo = { p =>
+
+    val inType      = method.inputType.scalaType
+    val outType     = method.outputType.scalaType
+    val descriptor  = s"_root_.$servicePkgName.${serviceName}Grpc.${method.descriptorName}"
+    val handler     = s"$Fs2ServerCallHandler[F].${handleMethod(method)}[$inType, $outType]"
+
+    val serviceCall = s"serviceImpl.${method.name}"
+    val eval        = if(method.isServerStreaming) s"$Stream.eval(g(m))" else "g(m)"
+
+    p.add(s".addMethod($descriptor, $handler((r, m) => $eval.flatMap($serviceCall(r, _))))")
+  }
+
+  private[this] def serviceMethods: PrinterEndo = _.seq(service.methods.map(serviceMethodSignature))
+
+  private[this] def serviceMethodImplementations: PrinterEndo =
+    _.call(service.methods.map(serviceMethodImplementation): _*)
+
+  private[this] def serviceBindingImplementations: PrinterEndo =
+    _.indent
+      .add(s".builder(_root_.$servicePkgName.${serviceName}Grpc.${service.descriptorName})")
+      .call(service.methods.map(serviceBindingImplementation): _*)
+      .add(".build()")
+      .outdent
+
+  private[this] def serviceTrait: PrinterEndo =
+    _.add(s"trait $serviceNameFs2[F[_], $Ctx] {").
+      indent.
+      call(serviceMethods).
+      outdent.
+      add("}")
+
+  private[this] def serviceObject: PrinterEndo =
+    _.add(s"object $serviceNameFs2 {").
+      indent.
+      newline.
+      call(serviceClientMeta).
+      newline.
+      call(serviceClient).
+      newline.
+      call(serviceBindingMeta).
+      newline.
+      call(serviceBinding).
+      outdent.
+      add("}")
+
+  private[this] def serviceClient: PrinterEndo = {
+    _.add(
+      s"def client[F[_]: $ConcurrentEffect, $Ctx](channel: $Channel, f: $Ctx => $Metadata, c: $CallOptions => $CallOptions = identity): $serviceNameFs2[F, $Ctx] = new $serviceNameFs2[F, $Ctx] {")
+      .indent
+      .call(serviceMethodImplementations)
+      .outdent
+      .add("}")
+  }
+
+  private[this] def serviceBinding: PrinterEndo = {
+    _.add(
+      s"def service[F[_]: $ConcurrentEffect, $Ctx](serviceImpl: $serviceNameFs2[F, $Ctx], f: $Metadata => Either[$Error, $Ctx]): $ServerServiceDefinition = {")
+      .indent
+      .newline
+      .add(s"val g: $Metadata ⇒ F[$Ctx] = f(_).leftMap[Throwable]($FailedPrecondition.withDescription(_).asRuntimeException()).raiseOrPure[F]")
+      .newline
+      .add(s"$ServerServiceDefinition")
+      .call(serviceBindingImplementations)
+      .outdent
+      .add("}")
+  }
+
+  /// For those that prefer io.grpc.Metadata instead of parameterized context
+
+  private[this] def serviceClientMeta: PrinterEndo =
+    _.add(
+      s"def stub[F[_]: $ConcurrentEffect](channel: $Channel, callOptions: $CallOptions = $CallOptions.DEFAULT): $serviceNameFs2[F, $Metadata] = {")
+      .indent
+      .add(s"client[F, $Metadata](channel, identity, _ => callOptions)")
+      .outdent
+      .add("}")
+
+  private[this] def serviceBindingMeta: PrinterEndo = {
+    _.add(
+      s"def bindService[F[_]: $ConcurrentEffect](serviceImpl: $serviceNameFs2[F, $Metadata]): $ServerServiceDefinition = {")
+      .indent
+      .add(s"service[F, $Metadata](serviceImpl, _.asRight[$Error])")
+      .outdent
+      .add("}")
+  }
+
+  ///
+
+  def printService(printer: FunctionalPrinter): FunctionalPrinter = {
+    printer
+      .add(s"package $servicePkgName", "", "import _root_.cats.implicits._", "")
+      .call(serviceTrait)
+      .newline
+      .call(serviceObject)
+  }
+}
+
+object Fs2GrpcServicePrinter {
+
+  object constants {
+
+    private val effPkg  = "_root_.cats.effect"
+    private val grpcPkg = "_root_.io.grpc"
+    private val jrtPkg  = "_root_.org.lyranthe.fs2_grpc.java_runtime"
+    private val fs2Pkg  = "_root_.fs2"
+
+    ///
+
+    val Error                   = "String"
+    val Ctx                     = "A"
+
+    val ConcurrentEffect        = s"$effPkg.ConcurrentEffect"
+    val Stream                  = s"$fs2Pkg.Stream"
+
+    val Fs2ServerCallHandler    = s"$jrtPkg.server.Fs2ServerCallHandler"
+    val Fs2ClientCall           = s"$jrtPkg.client.Fs2ClientCall"
+
+    val ServerServiceDefinition = s"$grpcPkg.ServerServiceDefinition"
+    val CallOptions             = s"$grpcPkg.CallOptions"
+    val Channel                 = s"$grpcPkg.Channel"
+    val Metadata                = s"$grpcPkg.Metadata"
+    val FailedPrecondition      = s"$grpcPkg.Status.FAILED_PRECONDITION"
+
+  }
+
+}

--- a/sbt-java-gen/src/main/scala/Fs2GrpcPlugin.scala
+++ b/sbt-java-gen/src/main/scala/Fs2GrpcPlugin.scala
@@ -1,79 +1,14 @@
 package org.lyranthe.fs2_grpc.java_runtime.sbt_gen
 
-import com.google.protobuf.Descriptors.FileDescriptor
-import com.google.protobuf.ExtensionRegistry
-import com.google.protobuf.compiler.PluginProtos
-import com.google.protobuf.compiler.PluginProtos.{CodeGeneratorRequest, CodeGeneratorResponse}
+import org.lyranthe.fs2_grpc.java_gen.Fs2CodeGenerator
 import org.lyranthe.fs2_grpc.java_runtime.sbt_gen.Fs2GrpcPlugin.autoImport.scalapbCodeGenerators
-import protocbridge.{Artifact, JvmGenerator, ProtocCodeGenerator, Target}
+import protocbridge.{JvmGenerator, Target}
 import sbt._
 import sbt.Keys._
 import sbt.plugins.JvmPlugin
 import sbtprotoc.ProtocPlugin.autoImport.PB
-import scalapb.compiler.{FunctionalPrinter, GeneratorException, DescriptorImplicits, ProtobufGenerator}
-import scalapb.options.compiler.Scalapb
-import scala.collection.JavaConverters._
 
 sealed trait CodeGeneratorOption extends Product with Serializable
-
-class Fs2CodeGenerator(serviceSuffix: String) extends ProtocCodeGenerator {
-
-  def generateServiceFiles(file: FileDescriptor,
-                           di: DescriptorImplicits): Seq[PluginProtos.CodeGeneratorResponse.File] = {
-    file.getServices.asScala.map { service =>
-      val p = new Fs2GrpcServicePrinter(service, serviceSuffix, di)
-
-      import di.{ServiceDescriptorPimp, FileDescriptorPimp}
-      val code = p.printService(FunctionalPrinter()).result()
-      val b    = CodeGeneratorResponse.File.newBuilder()
-      b.setName(file.scalaDirectory + "/" + service.name + s"$serviceSuffix.scala")
-      b.setContent(code)
-      println(b.getName)
-      b.build
-    }
-  }
-
-  def handleCodeGeneratorRequest(request: PluginProtos.CodeGeneratorRequest): PluginProtos.CodeGeneratorResponse = {
-    val b = CodeGeneratorResponse.newBuilder
-    ProtobufGenerator.parseParameters(request.getParameter) match {
-      case Right(params) =>
-        try {
-
-          val filesByName: Map[String, FileDescriptor] =
-            request.getProtoFileList.asScala.foldLeft[Map[String, FileDescriptor]](Map.empty) {
-              case (acc, fp) =>
-                val deps = fp.getDependencyList.asScala.map(acc)
-                acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps.toArray))
-            }
-
-          val implicits = new DescriptorImplicits(params, filesByName.values.toVector)
-          val genFiles  = request.getFileToGenerateList.asScala.map(filesByName)
-          val srvFiles  = genFiles.flatMap(generateServiceFiles(_, implicits))
-          b.addAllFile(srvFiles.asJava)
-        } catch {
-          case e: GeneratorException =>
-            b.setError(e.message)
-        }
-
-      case Left(error) =>
-        b.setError(error)
-    }
-
-    b.build()
-  }
-
-  override def run(req: Array[Byte]): Array[Byte] = {
-    println("Running")
-    val registry = ExtensionRegistry.newInstance()
-    Scalapb.registerAllExtensions(registry)
-    val request = CodeGeneratorRequest.parseFrom(req, registry)
-    handleCodeGeneratorRequest(request).toByteArray
-  }
-
-  override def suggestedDependencies: Seq[Artifact] = Seq(
-    Artifact("com.thesamet.scalapb", "scalapb-runtime", scalapb.compiler.Version.scalapbVersion, crossVersion = true)
-  )
-}
 
 object Fs2Grpc extends AutoPlugin {
   override def requires: Plugins      = Fs2GrpcPlugin


### PR DESCRIPTION
Adds a new java-gen project for sbt-java-gen to depend on.  Extracts the Fs2CodeGenerator so it can be used outside SBT.

Fixes #67.