### PR TITLE
dependencies: Scala 2.13.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 scala:
-   - 2.11.12
+   - 2.13.0
    - 2.12.8
-   - 2.13.0-M5
+   - 2.11.12
 jdk:
   - oraclejdk8
   - openjdk11

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import Dependencies._
+
 inThisBuild(
   List(
     organization := "org.lyranthe.fs2-grpc",
@@ -36,25 +38,19 @@ lazy val `sbt-java-gen` = project
     sbtPlugin := true,
     crossSbtVersions := List(sbtVersion.value, "0.13.18"),
     buildInfoPackage := "org.lyranthe.fs2_grpc.buildinfo",
-    addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.23"),
-    libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % scalapb.compiler.Version.scalapbVersion
+    addSbtPlugin(sbtProtoc),
+    libraryDependencies += scalaPbCompiler
   )
 
 lazy val `java-runtime` = project
   .enablePlugins(GitVersioning)
   .settings(
-    scalaVersion := "2.12.8",
-    crossScalaVersions := List(scalaVersion.value, "2.11.12", "2.13.0-M5"),
+    scalaVersion := "2.13.0",
+    crossScalaVersions := List(scalaVersion.value, "2.12.8", "2.11.12"),
     publishTo := sonatypePublishTo.value,
-    libraryDependencies ++= List(
-      "co.fs2"        %% "fs2-core"         % "1.0.4",
-      "org.typelevel" %% "cats-effect"      % "1.3.1",
-      "org.typelevel" %% "cats-effect-laws" % "1.3.1" % "test",
-      "io.grpc"       % "grpc-core"         % scalapb.compiler.Version.grpcJavaVersion,
-      "io.grpc"       % "grpc-netty-shaded" % scalapb.compiler.Version.grpcJavaVersion % "test",
-      "io.monix"      %% "minitest"         % "2.3.2" % "test"
-    ),
+    libraryDependencies ++= List(fs2, catsEffect, grpcCore) ++ List(grpcNetty, catsEffectLaws, minitest).map(_  % Test),
     mimaPreviousArtifacts := Set(organization.value %% name.value % "0.3.0"),
+    Test / parallelExecution := false,
     testFrameworks += new TestFramework("minitest.runner.Framework"),
-    addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.9" cross CrossVersion.binary)
+    addCompilerPlugin(kindProjector)
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,37 @@
+import sbt._
+
+object Dependencies {
+
+  object versions {
+
+    val grpc          = scalapb.compiler.Version.grpcJavaVersion
+    val scalaPb       = scalapb.compiler.Version.scalapbVersion
+    val fs2           = "1.1.0-M1"
+    val catsEffect    = "2.0.0-M4"
+    val minitest      = "2.5.0"
+
+    val kindProjector = "0.10.3"
+    val sbtProtoc     = "0.99.23"
+
+  }
+
+
+  // Compile
+
+  val fs2            = "co.fs2"        %% "fs2-core"          % versions.fs2
+  val catsEffect     = "org.typelevel" %% "cats-effect"       % versions.catsEffect
+  val grpcCore       = "io.grpc"       %  "grpc-core"         % versions.grpc
+
+  // Testing
+
+  val catsEffectLaws = "org.typelevel" %% "cats-effect-laws"  % versions.catsEffect
+  val grpcNetty      = "io.grpc"       %  "grpc-netty-shaded" % versions.grpc
+  val minitest       = "io.monix"      %% "minitest"          % versions.minitest
+
+  // Compiler & SBT Plugins
+
+  val sbtProtoc       = "com.thesamet"         %  "sbt-protoc"     % versions.sbtProtoc
+  val scalaPbCompiler = "com.thesamet.scalapb" %% "compilerplugin" % versions.scalaPb
+  val kindProjector   = "org.typelevel"        %% "kind-projector" % versions.kindProjector cross CrossVersion.binary
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,6 +9,6 @@ addSbtPlugin("com.timushev.sbt" % "sbt-updates"   % "0.4.0")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.5")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.6")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.4"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.9.0-M7"


### PR DESCRIPTION
 - set 2.13.0 as default version.

 - upgrade fs2, cats-effect, minitest and ScalaPB.

 - add `Dependencies` project file to keep versions
   and dependencies separated from build.sbt

 - adjust travis to account for 2.13.0.

 - upgrade sbt-tpolecat to get 2.13.0 support.