### PR TITLE
openjdk8 and xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: scala
+dist: xenial
 scala:
    - 2.11.12
    - 2.12.8
    - 2.13.0-M5
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test


### PR DESCRIPTION
Travis CI builds have been bitrotting on oraclejdk8 for some time.