### PR TITLE
sbt-java-gen: fix deprecated usage of raiseOrPure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 dist: xenial
 scala:
    - 2.13.0
-   - 2.12.8
+   - 2.12.9
    - 2.11.12
 jdk:
   - openjdk8

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val `java-runtime` = project
   .enablePlugins(GitVersioning)
   .settings(
     scalaVersion := "2.13.0",
-    crossScalaVersions := List(scalaVersion.value, "2.12.8", "2.11.12"),
+    crossScalaVersions := List(scalaVersion.value, "2.12.9", "2.11.12"),
     publishTo := sonatypePublishTo.value,
     libraryDependencies ++= List(fs2, catsEffect, grpcCore) ++ List(grpcNetty, catsEffectLaws, minitest).map(_  % Test),
     mimaPreviousArtifacts := Set(organization.value %% name.value % "0.3.0"),

--- a/sbt-java-gen/src/main/scala/Fs2GrpcServicePrinter.scala
+++ b/sbt-java-gen/src/main/scala/Fs2GrpcServicePrinter.scala
@@ -114,7 +114,7 @@ class Fs2GrpcServicePrinter(service: ServiceDescriptor, serviceSuffix: String, d
       s"def service[F[_]: $ConcurrentEffect, $Ctx](serviceImpl: $serviceNameFs2[F, $Ctx], f: $Metadata => Either[$Error, $Ctx]): $ServerServiceDefinition = {")
       .indent
       .newline
-      .add(s"val g: $Metadata ⇒ F[$Ctx] = f(_).leftMap[Throwable]($FailedPrecondition.withDescription(_).asRuntimeException()).raiseOrPure[F]")
+      .add(s"val g: $Metadata ⇒ F[$Ctx] = f(_).leftMap[Throwable]($FailedPrecondition.withDescription(_).asRuntimeException()).liftTo[F]")
       .newline
       .add(s"$ServerServiceDefinition")
       .call(serviceBindingImplementations)


### PR DESCRIPTION
 - change usage of `raiseOrPure` to `liftTo` in
   generated service definition.

 - bump scala 2.12.x