### PR TITLE
all: move forward with dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 dist: xenial
 scala:
    - 2.13.0
-   - 2.12.8
+   - 2.12.9
    - 2.11.12
 jdk:
   - openjdk8

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ import Dependencies._
 
 inThisBuild(
   List(
+    scalaVersion := "2.12.9",
     organization := "org.lyranthe.fs2-grpc",
     git.useGitDescribe := true,
     scmInfo := Some(ScmInfo(url("https://github.com/fiadliel/fs2-grpc"), "git@github.com:fiadliel/fs2-grpc.git"))
@@ -46,7 +47,7 @@ lazy val `java-runtime` = project
   .enablePlugins(GitVersioning)
   .settings(
     scalaVersion := "2.13.0",
-    crossScalaVersions := List(scalaVersion.value, "2.12.8", "2.11.12"),
+    crossScalaVersions := List(scalaVersion.value, "2.12.9", "2.11.12"),
     publishTo := sonatypePublishTo.value,
     libraryDependencies ++= List(fs2, catsEffect, grpcCore) ++ List(grpcNetty, catsEffectLaws, minitest).map(_  % Test),
     mimaPreviousArtifacts := Set(organization.value %% name.value % "0.3.0"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,9 +6,9 @@ object Dependencies {
 
     val grpc          = scalapb.compiler.Version.grpcJavaVersion
     val scalaPb       = scalapb.compiler.Version.scalapbVersion
-    val fs2           = "1.1.0-M1"
-    val catsEffect    = "2.0.0-RC2"
-    val minitest      = "2.6.0"
+    val fs2           = "2.0.0"
+    val catsEffect    = "2.0.0"
+    val minitest      = "2.7.0"
 
     val kindProjector = "0.10.3"
     val sbtProtoc     = "0.99.23"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.0

--- a/sbt-java-gen/src/main/scala/Fs2GrpcServicePrinter.scala
+++ b/sbt-java-gen/src/main/scala/Fs2GrpcServicePrinter.scala
@@ -114,7 +114,7 @@ class Fs2GrpcServicePrinter(service: ServiceDescriptor, serviceSuffix: String, d
       s"def service[F[_]: $ConcurrentEffect, $Ctx](serviceImpl: $serviceNameFs2[F, $Ctx], f: $Metadata => Either[$Error, $Ctx]): $ServerServiceDefinition = {")
       .indent
       .newline
-      .add(s"val g: $Metadata ⇒ F[$Ctx] = f(_).leftMap[Throwable]($FailedPrecondition.withDescription(_).asRuntimeException()).raiseOrPure[F]")
+      .add(s"val g: $Metadata ⇒ F[$Ctx] = f(_).leftMap[Throwable]($FailedPrecondition.withDescription(_).asRuntimeException()).liftTo[F]")
       .newline
       .add(s"$ServerServiceDefinition")
       .call(serviceBindingImplementations)


### PR DESCRIPTION
 - change usage of `raiseOrPure` to `liftTo` in
   generated service definition.

 - bump fs2, cats-effect and minitest
 - bump scala 2.12.x
 - bump sbt 1.3.0