### PR TITLE
Drop sbt-0.13 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val `sbt-java-gen` = project
   .settings(
     publishTo := sonatypePublishTo.value,
     sbtPlugin := true,
-    crossSbtVersions := List(sbtVersion.value, "0.13.18"),
+    crossSbtVersions := List(sbtVersion.value),
     buildInfoPackage := "org.lyranthe.fs2_grpc.buildinfo",
     addSbtPlugin(sbtProtoc),
     libraryDependencies += scalaPbCompiler


### PR DESCRIPTION
It no longer resolves, I suspect because of the sbt-1.3.0 upgrade.  I can't imagine anybody is using fs2-grpc and still on sbt-0.13.  If I'm wrong, a PR is welcome.  It's probably just adding back a resolver or something.