### PR TITLE
revert: sbt-protoc as it changes defaults.

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.ignore = [
+  { groupId = "com.thesamet", artifactId = "sbt-protoc" }
+]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val minitest      = "2.7.0"
 
     val kindProjector = "0.10.3"
-    val sbtProtoc     = "0.99.26"
+    val sbtProtoc     = "0.99.25"
 
   }
 


### PR DESCRIPTION
 - revert sbt-protoc to 0.99.25 as 0.99.26 introduces
   changes to default settings and that breaks out of
   the box `.enablePlugins(Fs2Grpc)` behavior.

 - add scala steward config that ignores sbt-protoc
   until a solution is found.