### PR TITLE
plugin: adjust to sbt-protoc changed its defaults

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,3 +1,0 @@
-updates.ignore = [
-  { groupId = "com.thesamet", artifactId = "sbt-protoc" }
-]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val minitest      = "2.7.0"
 
     val kindProjector = "0.10.3"
-    val sbtProtoc     = "0.99.25"
+    val sbtProtoc     = "0.99.26"
 
   }
 

--- a/sbt-java-gen/src/main/scala/Fs2GrpcPlugin.scala
+++ b/sbt-java-gen/src/main/scala/Fs2GrpcPlugin.scala
@@ -80,7 +80,7 @@ object Fs2Grpc extends AutoPlugin {
   override def trigger: PluginTrigger = NoTrigger
 
   override def projectSettings: Seq[Def.Setting[_]] = List(
-    PB.targets := scalapbCodeGenerators.value
+    Compile / PB.targets := scalapbCodeGenerators.value
   )
 }
 


### PR DESCRIPTION
 - change scope of `PB.targets` setting to `Compile`
   as sbt-protoc 0.99.26 introduces changes in its
   default settings wrt. `PB.targets`. That breaks
   the out of the box `.enablePlugins(Fs2Grpc)`
   behavior.

 - remove scala-steward.conf and move to 0.99.26