### PR TITLE
deps: remove 2.11 + bump fs2 + 2.13 default

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,6 @@
+# https://github.com/scalameta/scalafmt/releases
+
+version = "2.3.2"
+
 align = true
 maxColumn = 120

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: scala
 dist: xenial
 scala:
-   - 2.13.0
-   - 2.12.9
-   - 2.11.12
+   - 2.13.1
+   - 2.12.10
 jdk:
   - openjdk8
   - openjdk11

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 
 inThisBuild(
   List(
-    scalaVersion := "2.12.9",
+    scalaVersion := "2.13.1",
     organization := "org.lyranthe.fs2-grpc",
     git.useGitDescribe := true,
     scmInfo := Some(ScmInfo(url("https://github.com/fiadliel/fs2-grpc"), "git@github.com:fiadliel/fs2-grpc.git"))
@@ -35,6 +35,7 @@ lazy val root = project.in(file("."))
 lazy val `sbt-java-gen` = project
   .enablePlugins(GitVersioning, BuildInfoPlugin)
   .settings(
+    scalaVersion := "2.12.10",
     publishTo := sonatypePublishToBundle.value,
     sbtPlugin := true,
     crossSbtVersions := List(sbtVersion.value),
@@ -46,8 +47,8 @@ lazy val `sbt-java-gen` = project
 lazy val `java-runtime` = project
   .enablePlugins(GitVersioning)
   .settings(
-    scalaVersion := "2.13.0",
-    crossScalaVersions := List(scalaVersion.value, "2.12.9", "2.11.12"),
+    scalaVersion := "2.13.1",
+    crossScalaVersions := List(scalaVersion.value, "2.12.10"),
     publishTo := sonatypePublishToBundle.value,
     libraryDependencies ++= List(fs2, catsEffect, grpcCore) ++ List(grpcNetty, catsEffectLaws, minitest).map(_  % Test),
     mimaPreviousArtifacts := Set(organization.value %% name.value % "0.3.0"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
 
     val grpc          = scalapb.compiler.Version.grpcJavaVersion
     val scalaPb       = scalapb.compiler.Version.scalapbVersion
-    val fs2           = "2.1.0"
+    val fs2           = "2.2.1"
     val catsEffect    = "2.0.0"
     val minitest      = "2.7.0"
 


### PR DESCRIPTION
 - remove support from Scala 2.11 as most of upstream
   is doing that.

 - set Scala 2.13.x as default for `ThisBuild` and use
   2.12.10 for plugin.