### PR TITLE
Upgrade to ScalaPB 0.10.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,34 +4,33 @@ object Dependencies {
 
   object versions {
 
-    val grpc          = scalapb.compiler.Version.grpcJavaVersion
-    val scalaPb       = scalapb.compiler.Version.scalapbVersion
-    val fs2           = "2.2.2"
-    val catsEffect    = "2.1.1"
-    val minitest      = "2.7.0"
+    val grpc = scalapb.compiler.Version.grpcJavaVersion
+    val scalaPb = scalapb.compiler.Version.scalapbVersion
+    val fs2 = "2.2.2"
+    val catsEffect = "2.1.1"
+    val minitest = "2.7.0"
 
     val kindProjector = "0.10.3"
-    val sbtProtoc     = "0.99.27"
+    val sbtProtoc = "0.99.28"
 
   }
 
-
   // Compile
 
-  val fs2            = "co.fs2"        %% "fs2-core"          % versions.fs2
-  val catsEffect     = "org.typelevel" %% "cats-effect"       % versions.catsEffect
-  val grpcCore       = "io.grpc"       %  "grpc-core"         % versions.grpc
+  val fs2 = "co.fs2" %% "fs2-core" % versions.fs2
+  val catsEffect = "org.typelevel" %% "cats-effect" % versions.catsEffect
+  val grpcCore = "io.grpc" % "grpc-core" % versions.grpc
 
   // Testing
 
-  val catsEffectLaws = "org.typelevel" %% "cats-effect-laws"  % versions.catsEffect
-  val grpcNetty      = "io.grpc"       %  "grpc-netty-shaded" % versions.grpc
-  val minitest       = "io.monix"      %% "minitest"          % versions.minitest
+  val catsEffectLaws = "org.typelevel" %% "cats-effect-laws" % versions.catsEffect
+  val grpcNetty = "io.grpc" % "grpc-netty-shaded" % versions.grpc
+  val minitest = "io.monix" %% "minitest" % versions.minitest
 
   // Compiler & SBT Plugins
 
-  val sbtProtoc       = "com.thesamet"         %  "sbt-protoc"     % versions.sbtProtoc
+  val sbtProtoc = "com.thesamet" % "sbt-protoc" % versions.sbtProtoc
   val scalaPbCompiler = "com.thesamet.scalapb" %% "compilerplugin" % versions.scalaPb
-  val kindProjector   = "org.typelevel"        %% "kind-projector" % versions.kindProjector cross CrossVersion.binary
+  val kindProjector = "org.typelevel" %% "kind-projector" % versions.kindProjector cross CrossVersion.binary
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,14 @@
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
-addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype" % "3.8.1")
-addSbtPlugin("com.jsuereth"     % "sbt-pgp"      % "2.0.1")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git"      % "1.0.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
-addSbtPlugin("com.eed3si9n"     % "sbt-buildinfo" % "0.9.0")
-addSbtPlugin("org.scalameta"     % "sbt-scalafmt"  % "2.3.2")
-addSbtPlugin("com.timushev.sbt" % "sbt-updates"   % "0.5.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.2")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.0")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.4")
 
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.10")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.9.6"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.1"


### PR DESCRIPTION
 - bump ScalaPB to 0.10.1 and adjust codegen
   a bit with respect to method naming and 
   fix deprecations.

 - formatting is scalafmt