### PR TITLE
only rely on grpc-api + prepare for controlling grpc version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,11 @@ inThisBuild(
     organization := "org.lyranthe.fs2-grpc",
     git.useGitDescribe := true,
     scmInfo := Some(ScmInfo(url("https://github.com/fiadliel/fs2-grpc"), "git@github.com:fiadliel/fs2-grpc.git"))
-  ))
+  )
+)
 
-lazy val root = project.in(file("."))
+lazy val root = project
+  .in(file("."))
   .enablePlugins(GitVersioning, BuildInfoPlugin)
   .settings(
     sonatypeProfileName := "org.lyranthe",
@@ -40,6 +42,14 @@ lazy val `sbt-java-gen` = project
     sbtPlugin := true,
     crossSbtVersions := List(sbtVersion.value),
     buildInfoPackage := "org.lyranthe.fs2_grpc.buildinfo",
+    buildInfoKeys := Seq[BuildInfoKey](
+      name,
+      version,
+      scalaVersion,
+      sbtVersion,
+      organization,
+      "grpcVersion" -> versions.grpc
+    ),
     addSbtPlugin(sbtProtoc),
     libraryDependencies += scalaPbCompiler
   )
@@ -50,7 +60,7 @@ lazy val `java-runtime` = project
     scalaVersion := "2.13.1",
     crossScalaVersions := List(scalaVersion.value, "2.12.10"),
     publishTo := sonatypePublishToBundle.value,
-    libraryDependencies ++= List(fs2, catsEffect, grpcCore) ++ List(grpcNetty, catsEffectLaws, minitest).map(_  % Test),
+    libraryDependencies ++= List(fs2, catsEffect, grpcApi) ++ List(grpcNetty, catsEffectLaws, minitest).map(_ % Test),
     mimaPreviousArtifacts := Set(organization.value %% name.value % "0.3.0"),
     Test / parallelExecution := false,
     testFrameworks += new TestFramework("minitest.runner.Framework"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
 
   val fs2 = "co.fs2" %% "fs2-core" % versions.fs2
   val catsEffect = "org.typelevel" %% "cats-effect" % versions.catsEffect
-  val grpcCore = "io.grpc" % "grpc-core" % versions.grpc
+  val grpcApi = "io.grpc" % "grpc-api" % versions.grpc
 
   // Testing
 

--- a/sbt-java-gen/src/main/scala/Fs2GrpcPlugin.scala
+++ b/sbt-java-gen/src/main/scala/Fs2GrpcPlugin.scala
@@ -13,6 +13,7 @@ import sbtprotoc.ProtocPlugin.autoImport.PB
 import scalapb.compiler.{FunctionalPrinter, GeneratorException, DescriptorImplicits, ProtobufGenerator}
 import scalapb.options.compiler.Scalapb
 import scala.collection.JavaConverters._
+import org.lyranthe.fs2_grpc.buildinfo.BuildInfo
 
 sealed trait CodeGeneratorOption extends Product with Serializable
 
@@ -158,9 +159,10 @@ object Fs2GrpcPlugin extends AutoPlugin {
     },
     scalapbCodeGeneratorOptions := Seq(CodeGeneratorOption.Grpc, CodeGeneratorOption.Fs2Grpc),
     libraryDependencies ++= List(
-      "io.grpc" % "grpc-core" % scalapb.compiler.Version.grpcJavaVersion,
-      "io.grpc" % "grpc-stub" % scalapb.compiler.Version.grpcJavaVersion,
-      "org.lyranthe.fs2-grpc" %% "java-runtime" % org.lyranthe.fs2_grpc.buildinfo.BuildInfo.version,
+      "io.grpc" % "grpc-core" % BuildInfo.grpcVersion,
+      "io.grpc" % "grpc-stub" % BuildInfo.grpcVersion,
+      "io.grpc" % "grpc-protobuf" % BuildInfo.grpcVersion,
+      BuildInfo.organization %% "java-runtime" % BuildInfo.version,
       "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion,
       "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion
     )


### PR DESCRIPTION
 - change plugin to use grpc version from build-info
   and use organization from build-info instead in order
   to make it possible to use a different organization
   in build.

 - change dependency on grpc for runtime to only rely
   on grpc-api as grpc-core is not needed.