### PR TITLE
Remove sbt-coursier

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")


### PR DESCRIPTION
Shouldn't be necessary in modern SBT, and is generating Scala Steward noise.

Replaces #230.