### PR TITLE
build: add e2e project for codegen verification

### DIFF
--- a/e2e/src/main/protobuf/package.proto
+++ b/e2e/src/main/protobuf/package.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+
+import "scalapb/scalapb.proto";
+
+package io.fs2.grpc;
+
+option (scalapb.options) = {
+  scope: PACKAGE
+  flat_package: true
+};

--- a/e2e/src/main/protobuf/test.proto
+++ b/e2e/src/main/protobuf/test.proto
@@ -1,0 +1,22 @@
+syntax = "proto2";
+
+package io.fs2.grpc;
+
+enum Color {
+  UNKNOWN = 0;
+  RED     = 1;
+  GREEN   = 2;
+  BLUE    = 3;
+}
+
+message TestMessage {
+  
+  message NestedMessage {
+    required Color color = 1;
+  }
+
+  required string        a = 1;
+  required int32         b = 2;
+  optional NestedMessage c = 3;
+
+}

--- a/e2e/src/main/protobuf/test_service.proto
+++ b/e2e/src/main/protobuf/test_service.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+import "test.proto";
+
+package io.fs2.grpc;
+
+service TestService {  
+  rpc noStreaming (TestMessage) returns (TestMessage);
+  rpc clientStreaming (stream TestMessage) returns (TestMessage);
+  rpc serverStreaming (TestMessage) returns (stream TestMessage);
+  rpc bothStreaming (stream TestMessage) returns (stream TestMessage);
+}

--- a/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
@@ -1,0 +1,39 @@
+package io.fs2.grpc
+
+import _root_.cats.syntax.all._
+
+trait TestServiceFs2Grpc[F[_], A] {
+  def noStreaming(request: io.fs2.grpc.TestMessage, ctx: A): F[io.fs2.grpc.TestMessage]
+  def clientStreaming(request: _root_.fs2.Stream[F, io.fs2.grpc.TestMessage], ctx: A): F[io.fs2.grpc.TestMessage]
+  def serverStreaming(request: io.fs2.grpc.TestMessage, ctx: A): _root_.fs2.Stream[F, io.fs2.grpc.TestMessage]
+  def bothStreaming(request: _root_.fs2.Stream[F, io.fs2.grpc.TestMessage], ctx: A): _root_.fs2.Stream[F, io.fs2.grpc.TestMessage]
+}
+
+object TestServiceFs2Grpc extends _root_.org.lyranthe.fs2_grpc.java_runtime.GeneratedCompanion[TestServiceFs2Grpc] {
+  
+  def client[F[_]: _root_.cats.effect.Async, A](dispatcher: _root_.cats.effect.std.Dispatcher[F], channel: _root_.io.grpc.Channel, mkMeta: A => _root_.io.grpc.Metadata, coFn: _root_.io.grpc.CallOptions => _root_.io.grpc.CallOptions = identity, errorAdapter: _root_.io.grpc.StatusRuntimeException => Option[Exception] = _ => None): TestServiceFs2Grpc[F, A] = new TestServiceFs2Grpc[F, A] {
+    def noStreaming(request: io.fs2.grpc.TestMessage, ctx: A): F[io.fs2.grpc.TestMessage] = {
+      _root_.org.lyranthe.fs2_grpc.java_runtime.client.Fs2ClientCall[F](channel, io.fs2.grpc.TestServiceGrpc.METHOD_NO_STREAMING, coFn(_root_.io.grpc.CallOptions.DEFAULT), dispatcher, errorAdapter).flatMap(_.unaryToUnaryCall(request, mkMeta(ctx)))
+    }
+    def clientStreaming(request: _root_.fs2.Stream[F, io.fs2.grpc.TestMessage], ctx: A): F[io.fs2.grpc.TestMessage] = {
+      _root_.org.lyranthe.fs2_grpc.java_runtime.client.Fs2ClientCall[F](channel, io.fs2.grpc.TestServiceGrpc.METHOD_CLIENT_STREAMING, coFn(_root_.io.grpc.CallOptions.DEFAULT), dispatcher, errorAdapter).flatMap(_.streamingToUnaryCall(request, mkMeta(ctx)))
+    }
+    def serverStreaming(request: io.fs2.grpc.TestMessage, ctx: A): _root_.fs2.Stream[F, io.fs2.grpc.TestMessage] = {
+      _root_.fs2.Stream.eval(_root_.org.lyranthe.fs2_grpc.java_runtime.client.Fs2ClientCall[F](channel, io.fs2.grpc.TestServiceGrpc.METHOD_SERVER_STREAMING, coFn(_root_.io.grpc.CallOptions.DEFAULT), dispatcher, errorAdapter)).flatMap(_.unaryToStreamingCall(request, mkMeta(ctx)))
+    }
+    def bothStreaming(request: _root_.fs2.Stream[F, io.fs2.grpc.TestMessage], ctx: A): _root_.fs2.Stream[F, io.fs2.grpc.TestMessage] = {
+      _root_.fs2.Stream.eval(_root_.org.lyranthe.fs2_grpc.java_runtime.client.Fs2ClientCall[F](channel, io.fs2.grpc.TestServiceGrpc.METHOD_BOTH_STREAMING, coFn(_root_.io.grpc.CallOptions.DEFAULT), dispatcher, errorAdapter)).flatMap(_.streamingToStreamingCall(request, mkMeta(ctx)))
+    }
+  }
+  
+  protected def serviceBinding[F[_]: _root_.cats.effect.Async, A](dispatcher: _root_.cats.effect.std.Dispatcher[F], serviceImpl: TestServiceFs2Grpc[F, A], mkCtx: _root_.io.grpc.Metadata => F[A]): _root_.io.grpc.ServerServiceDefinition = {
+    _root_.io.grpc.ServerServiceDefinition
+      .builder(io.fs2.grpc.TestServiceGrpc.SERVICE)
+      .addMethod(io.fs2.grpc.TestServiceGrpc.METHOD_NO_STREAMING, _root_.org.lyranthe.fs2_grpc.java_runtime.server.Fs2ServerCallHandler[F](dispatcher).unaryToUnaryCall[io.fs2.grpc.TestMessage, io.fs2.grpc.TestMessage]((r, m) => mkCtx(m).flatMap(serviceImpl.noStreaming(r, _))))
+      .addMethod(io.fs2.grpc.TestServiceGrpc.METHOD_CLIENT_STREAMING, _root_.org.lyranthe.fs2_grpc.java_runtime.server.Fs2ServerCallHandler[F](dispatcher).streamingToUnaryCall[io.fs2.grpc.TestMessage, io.fs2.grpc.TestMessage]((r, m) => mkCtx(m).flatMap(serviceImpl.clientStreaming(r, _))))
+      .addMethod(io.fs2.grpc.TestServiceGrpc.METHOD_SERVER_STREAMING, _root_.org.lyranthe.fs2_grpc.java_runtime.server.Fs2ServerCallHandler[F](dispatcher).unaryToStreamingCall[io.fs2.grpc.TestMessage, io.fs2.grpc.TestMessage]((r, m) => _root_.fs2.Stream.eval(mkCtx(m)).flatMap(serviceImpl.serverStreaming(r, _))))
+      .addMethod(io.fs2.grpc.TestServiceGrpc.METHOD_BOTH_STREAMING, _root_.org.lyranthe.fs2_grpc.java_runtime.server.Fs2ServerCallHandler[F](dispatcher).streamingToStreamingCall[io.fs2.grpc.TestMessage, io.fs2.grpc.TestMessage]((r, m) => _root_.fs2.Stream.eval(mkCtx(m)).flatMap(serviceImpl.bothStreaming(r, _))))
+      .build()
+  }
+
+}

--- a/e2e/src/test/scala/io/fs2/grpc/CodegenSpec.scala
+++ b/e2e/src/test/scala/io/fs2/grpc/CodegenSpec.scala
@@ -1,0 +1,21 @@
+package io.fs2.grpc
+
+import java.io.File
+import scala.io.Source
+import buildinfo.BuildInfo.sourceManaged
+
+class Fs2CodeGeneratorSpec extends munit.FunSuite {
+
+  val sourcesGenerated = new File(sourceManaged.getAbsolutePath, "/io/fs2/grpc/")
+
+  test("code generator outputs correct service file") {
+
+    val testFileName = "TestServiceFs2Grpc.scala"
+    val reference = Source.fromResource(s"${testFileName}.txt").getLines().mkString("\n")
+    val generated = Source.fromFile(new File(sourcesGenerated, testFileName)).getLines().mkString("\n")
+
+    assertEquals(generated, reference)
+
+  }
+
+}

--- a/java-gen/src/main/scala/Fs2CodeGenerator.scala
+++ b/java-gen/src/main/scala/Fs2CodeGenerator.scala
@@ -6,7 +6,7 @@ import com.google.protobuf.compiler.PluginProtos
 import com.google.protobuf.compiler.PluginProtos.{CodeGeneratorRequest, CodeGeneratorResponse}
 import protocbridge.ProtocCodeGenerator
 import scalapb.compiler.{FunctionalPrinter, GeneratorException, DescriptorImplicits, GeneratorParams}
-import scalapb.options.compiler.Scalapb
+import scalapb.options.Scalapb
 import scala.collection.JavaConverters._
 
 case class Fs2Params(serviceSuffix: String = "Fs2Grpc")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,6 +31,9 @@ object Dependencies {
 
   val sbtProtoc = "com.thesamet" % "sbt-protoc" % versions.sbtProtoc
   val scalaPbCompiler = "com.thesamet.scalapb" %% "compilerplugin" % versions.scalaPb
+  val scalaPbRuntime = "com.thesamet.scalapb" %% "scalapb-runtime" % versions.scalaPb
+  val scalaPbGrpcRuntime = "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % versions.scalaPb
+
   val kindProjector = "org.typelevel" %% "kind-projector" % versions.kindProjector cross CrossVersion.binary
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,5 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.15")
 addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.9.4")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.8"
+addSbtPlugin("com.thesamet" % "sbt-protoc-gen-project" % "0.1.4")
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.9"


### PR DESCRIPTION
 - define test for generated code.
 - bump scalapb to 10.9 and fix deprecation warning
    wrt. `ScalaPb` object moved to `scalapb.options`.