### PR TITLE
deps: move ce/fs2 forward

### DIFF
--- a/java-runtime/src/main/scala/client/Fs2StreamClientCallListener.scala
+++ b/java-runtime/src/main/scala/client/Fs2StreamClientCallListener.scala
@@ -2,44 +2,39 @@ package org.lyranthe.fs2_grpc
 package java_runtime
 package client
 
-import cats.ApplicativeError
-import cats.effect.kernel.Concurrent
-import cats.effect.std.Dispatcher
+import cats.MonadError
 import cats.implicits._
-import fs2.{Pull, Stream}
-import fs2.concurrent.Queue
+import cats.effect.kernel.Concurrent
+import cats.effect.std.{Dispatcher, Queue}
+import fs2.Stream
 import io.grpc.{ClientCall, Metadata, Status}
 
 class Fs2StreamClientCallListener[F[_], Response] private (
     request: Int => Unit,
     queue: Queue[F, Either[GrpcStatus, Response]],
     dispatcher: Dispatcher[F]
-)(implicit F: ApplicativeError[F, Throwable])
+)(implicit F: MonadError[F, Throwable])
     extends ClientCall.Listener[Response] {
 
   override def onMessage(message: Response): Unit = {
     request(1)
-    dispatcher.unsafeRunSync(queue.enqueue1(message.asRight))
+    dispatcher.unsafeRunSync(queue.offer(message.asRight))
   }
 
   override def onClose(status: Status, trailers: Metadata): Unit =
-    dispatcher.unsafeRunSync(queue.enqueue1(GrpcStatus(status, trailers).asLeft))
+    dispatcher.unsafeRunSync(queue.offer(GrpcStatus(status, trailers).asLeft))
 
   def stream: Stream[F, Response] = {
 
-    def go(q: Stream[F, Either[GrpcStatus, Response]]): Pull[F, Response, Unit] = {
-      q.pull.uncons1.flatMap {
-        case Some((Right(v), tl)) => Pull.output1(v) >> go(tl)
-        case Some((Left(GrpcStatus(status, trailers)), _)) =>
-          if (!status.isOk)
-            Pull.raiseError[F](status.asRuntimeException(trailers))
-          else
-            Pull.done
-        case None => Pull.done
+    val run: F[Option[Response]] =
+      queue.take.flatMap {
+        case Right(v) => v.some.pure[F]
+        case Left(GrpcStatus(status, trailers)) =>
+          if (!status.isOk) F.raiseError(status.asRuntimeException(trailers))
+          else none[Response].pure[F]
       }
-    }
 
-    go(queue.dequeue).stream
+    Stream.repeatEval(run).unNoneTerminate
   }
 }
 

--- a/java-runtime/src/main/scala/syntax/ManagedChannelBuilderSyntax.scala
+++ b/java-runtime/src/main/scala/syntax/ManagedChannelBuilderSyntax.scala
@@ -58,7 +58,7 @@ final class ManagedChannelBuilderOps(val builder: ManagedChannelBuilder[_]) exte
     *
     * For different tradeoffs in shutdown behavior, see {{streamWithShutdown}}.
     */
-  def stream[F[_]](implicit F: Sync[F]): Stream[F, ManagedChannel] =
+  def stream[F[_]](implicit F: Async[F]): Stream[F, ManagedChannel] =
     Stream.resource(resource[F])
 
   /** Builds a `ManagedChannel` into a bracketed stream. The managed channel is
@@ -68,6 +68,6 @@ final class ManagedChannelBuilderOps(val builder: ManagedChannelBuilder[_]) exte
     * channel, with respect to forceful vs. graceful shutdown and how to poll
     * or block for termination.
     */
-  def streamWithShutdown[F[_]](shutdown: ManagedChannel => F[Unit])(implicit F: Sync[F]): Stream[F, ManagedChannel] =
+  def streamWithShutdown[F[_]](shutdown: ManagedChannel => F[Unit])(implicit F: Async[F]): Stream[F, ManagedChannel] =
     Stream.resource(resourceWithShutdown(shutdown))
 }

--- a/java-runtime/src/main/scala/syntax/ServerBuilderSyntax.scala
+++ b/java-runtime/src/main/scala/syntax/ServerBuilderSyntax.scala
@@ -56,7 +56,7 @@ final class ServerBuilderOps(val builder: ServerBuilder[_]) extends AnyVal {
     *
     * For different tradeoffs in shutdown behavior, see {{streamWithShutdown}}.
     */
-  def stream[F[_]](implicit F: Sync[F]): Stream[F, Server] =
+  def stream[F[_]](implicit F: Async[F]): Stream[F, Server] =
     Stream.resource(resource[F])
 
   /** Builds a `Server` into a bracketed stream. The server is shut
@@ -66,6 +66,6 @@ final class ServerBuilderOps(val builder: ServerBuilder[_]) extends AnyVal {
     * server, with respect to forceful vs. graceful shutdown and how
     * to poll or block for termination.
     */
-  def streamWithShutdown[F[_]](shutdown: Server => F[Unit])(implicit F: Sync[F]): Stream[F, Server] =
+  def streamWithShutdown[F[_]](shutdown: Server => F[Unit])(implicit F: Async[F]): Stream[F, Server] =
     Stream.resource(resourceWithShutdown(shutdown))
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
     val grpc = scalapb.compiler.Version.grpcJavaVersion
     val scalaPb = scalapb.compiler.Version.scalapbVersion
 
-    val fs2 = "3.0.0-M6"
-    val catsEffect = "3.0.0-M4"
-    val ceMunit = "0.11.0"
+    val fs2 = "3.0.0-M7"
+    val catsEffect = "3.0.0-M5"
+    val ceMunit = "0.12.0"
 
     val kindProjector = "0.10.3"
     val sbtProtoc = "0.99.34"


### PR DESCRIPTION
- use `cats.effect.std.Queue` as
   `fs.concurrent.std.Queue` is deprecated.

 - `Stream.resource` requires `MonadCancel` now,
    using `Async` instead of `Sync`.