### PR TITLE
java-runtime: handle exit case + syntax

### DIFF
--- a/java-runtime/src/main/scala/syntax/ManagedChannelBuilderSyntax.scala
+++ b/java-runtime/src/main/scala/syntax/ManagedChannelBuilderSyntax.scala
@@ -9,11 +9,13 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent._
 
 trait ManagedChannelBuilderSyntax {
-  implicit final def fs2GrpcSyntaxManagedChannelBuilder(builder: ManagedChannelBuilder[_]): ManagedChannelBuilderOps =
-    new ManagedChannelBuilderOps(builder)
+  implicit final def fs2GrpcSyntaxManagedChannelBuilder[MCB <: ManagedChannelBuilder[MCB]](
+      builder: MCB
+  ): ManagedChannelBuilderOps[MCB] =
+    new ManagedChannelBuilderOps[MCB](builder)
 }
 
-final class ManagedChannelBuilderOps(val builder: ManagedChannelBuilder[_]) extends AnyVal {
+final class ManagedChannelBuilderOps[MCB <: ManagedChannelBuilder[MCB]](val builder: MCB) extends AnyVal {
 
   /** Builds a `ManagedChannel` into a bracketed stream. The managed channel is
     * shut down when the stream is complete.  Shutdown is as follows:

--- a/java-runtime/src/main/scala/syntax/ServerBuilderSyntax.scala
+++ b/java-runtime/src/main/scala/syntax/ServerBuilderSyntax.scala
@@ -9,11 +9,11 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent._
 
 trait ServerBuilderSyntax {
-  implicit final def fs2GrpcSyntaxServerBuilder(builder: ServerBuilder[_]): ServerBuilderOps =
-    new ServerBuilderOps(builder)
+  implicit final def fs2GrpcSyntaxServerBuilder[SB <: ServerBuilder[SB]](builder: SB): ServerBuilderOps[SB] =
+    new ServerBuilderOps[SB](builder)
 }
 
-final class ServerBuilderOps(val builder: ServerBuilder[_]) extends AnyVal {
+final class ServerBuilderOps[SB <: ServerBuilder[SB]](val builder: SB) extends AnyVal {
 
   /** Builds a `Server` into a bracketed resource. The server is shut
     * down when the resource is released. Shutdown is as follows:


### PR DESCRIPTION
 - rename `handleCallError` to `handleExitCase` and account
   for invoking cancel in case of successful exit when using
   stream client call listener.

 - make `ManagedChannelBuilderSyntax` and `ServerBuilderSyntax`
   use explicit type params instead of `[_]`.