### PR TITLE
java-runtime: split syntax into Scala3 / Scala2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,8 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
+      - name: Run scalafmtCheckAll
+        run: sbt ++${{ matrix.scala }} scalafmtCheckAll
+
       - name: Run tests
-        run: sbt ++${{ matrix.scala }} scalafmtCheckAll test
+        run: sbt ++${{ matrix.scala }} test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.class
 *.log
 

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,3 +4,7 @@ version = "2.7.5"
 
 align.preset = none
 maxColumn = 120
+
+project.excludeFilters = [
+   ".*/scala-3/*"
+]

--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,12 @@ inThisBuild(
     githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@1.11"),
     githubWorkflowBuild := Seq(
       WorkflowStep.Sbt(
+        name = Some("Run scalafmtCheckAll"),
+        commands = List("scalafmtCheckAll")
+      ),
+      WorkflowStep.Sbt(
         name = Some("Run tests"),
-        commands = List("scalafmtCheckAll", "test")
+        commands = List("test")
       )
     ),
     githubWorkflowPublishTargetBranches := Nil

--- a/java-runtime/src/main/scala-3/syntax/ManagedChannelBuilderSyntax.scala
+++ b/java-runtime/src/main/scala-3/syntax/ManagedChannelBuilderSyntax.scala
@@ -1,0 +1,61 @@
+package org.lyranthe.fs2_grpc
+package java_runtime
+package syntax
+
+import cats.effect.{Sync, Resource}
+import fs2.Stream
+import io.grpc.{ManagedChannel, ManagedChannelBuilder}
+
+trait ManagedChannelBuilderSyntax {
+  
+  extension [MCB <: ManagedChannelBuilder[MCB]](builder: MCB) {
+
+    /** Builds a `ManagedChannel` into a bracketed stream. The managed channel is
+      * shut down when the stream is complete.  Shutdown is as follows:
+      *
+      * 1. We request an orderly shutdown, allowing preexisting calls to continue
+      *    without accepting new calls.
+      * 2. We block for up to 30 seconds on termination, using the blocking context
+      * 3. If the channel is not yet terminated, we trigger a forceful shutdown
+      *
+      * For different tradeoffs in shutdown behavior, see {{resourceWithShutdown}}.
+      */
+      def resource[F[_]: Sync]: Resource[F, ManagedChannel] =
+        channelResource[F, MCB](builder)
+
+    /** Builds a `ManagedChannel` into a bracketed resource. The managed channel is
+      * shut down when the resource is released.
+      *
+      * @param shutdown Determines the behavior of the cleanup of the managed
+      * channel, with respect to forceful vs. graceful shutdown and how to poll
+      * or block for termination.
+      */
+      def resourceWithShutdown[F[_]: Sync](shutdown: ManagedChannel => F[Unit]): Resource[F, ManagedChannel] =
+        channelResourceWithShutdown[F, MCB](builder)(shutdown)
+
+    /** Builds a `ManagedChannel` into a bracketed stream. The managed channel is
+      * shut down when the resource is released.  Shutdown is as follows:
+      *
+      * 1. We request an orderly shutdown, allowing preexisting calls to continue
+      *    without accepting new calls.
+      * 2. We block for up to 30 seconds on termination, using the blocking context
+      * 3. If the channel is not yet terminated, we trigger a forceful shutdown
+      *
+      * For different tradeoffs in shutdown behavior, see {{streamWithShutdown}}.
+      */
+      def stream[F[_]: Sync]: Stream[F, ManagedChannel] =
+        Stream.resource(resource[F])
+
+    /** Builds a `ManagedChannel` into a bracketed stream. The managed channel is
+      * shut down when the stream is complete.
+      *
+      * @param shutdown Determines the behavior of the cleanup of the managed
+      * channel, with respect to forceful vs. graceful shutdown and how to poll
+      * or block for termination.
+      */
+      def streamWithShutdown[F[_]: Sync](shutdown: ManagedChannel => F[Unit]): Stream[F, ManagedChannel] =
+        Stream.resource(resourceWithShutdown[F](shutdown))
+
+  }
+
+}

--- a/java-runtime/src/main/scala-3/syntax/ServerBuilderSyntax.scala
+++ b/java-runtime/src/main/scala-3/syntax/ServerBuilderSyntax.scala
@@ -1,0 +1,62 @@
+package org.lyranthe.fs2_grpc
+package java_runtime
+package syntax
+
+import cats.effect.{Sync, Resource}
+import fs2.Stream
+import io.grpc.{Server, ServerBuilder}
+
+trait ServerBuilderSyntax {
+
+  extension [SB <: ServerBuilder[SB]](builder: SB) {
+    
+      /** Builds a `Server` into a bracketed resource. The server is shut
+        * down when the resource is released. Shutdown is as follows:
+        *
+        * 1. We request an orderly shutdown, allowing preexisting calls to continue
+        *    without accepting new calls.
+        * 2. We block for up to 30 seconds on termination, using the blocking context
+        * 3. If the server is not yet terminated, we trigger a forceful shutdown
+        *
+        * For different tradeoffs in shutdown behavior, see {{resourceWithShutdown}}.
+        */
+      def resource[F[_]: Sync]: Resource[F, Server] = 
+        serverResource[F, SB](builder)
+
+      /** Builds a `Server` into a bracketed resource. The server is shut
+        * down when the resource is released.
+        *
+        * @param shutdown Determines the behavior of the cleanup of the
+        * server, with respect to forceful vs. graceful shutdown and how
+        * to poll or block for termination.
+        */
+      def resourceWithShutdown[F[_]: Sync](shutdown: Server => F[Unit]): Resource[F, Server] =
+        serverResourceWithShutdown[F, SB](builder)(shutdown)    
+
+
+      /** Builds a `Server` into a bracketed stream. The server is shut
+        * down when the stream is complete.  Shutdown is as follows:
+        *
+        * 1. We request an orderly shutdown, allowing preexisting calls to continue
+        *    without accepting new calls.
+        * 2. We block for up to 30 seconds on termination, using the blocking context
+        * 3. If the server is not yet terminated, we trigger a forceful shutdown
+        *
+        * For different tradeoffs in shutdown behavior, see {{streamWithShutdown}}.
+        */
+      def stream[F[_]: Sync]: Stream[F, Server] =
+        Stream.resource(resource[F])
+
+      /** Builds a `Server` into a bracketed stream. The server is shut
+        * down when the stream is complete.
+        *
+        * @param shutdown Determines the behavior of the cleanup of the
+        * server, with respect to forceful vs. graceful shutdown and how
+        * to poll or block for termination.
+        */
+      def streamWithShutdown[F[_]: Sync](shutdown: Server => F[Unit]): Stream[F, Server] =
+        Stream.resource(resourceWithShutdown[F](shutdown))
+
+  }
+  
+}

--- a/java-runtime/src/main/scala/syntax/package.scala
+++ b/java-runtime/src/main/scala/syntax/package.scala
@@ -1,8 +1,53 @@
 package org.lyranthe.fs2_grpc
 package java_runtime
 
+import cats.effect._
+import io.grpc.{ManagedChannel, ManagedChannelBuilder, Server, ServerBuilder}
+import java.util.concurrent.TimeUnit
+import scala.concurrent._
+
 package object syntax {
+
   object all extends AllSyntax
   object managedChannelBuilder extends ManagedChannelBuilderSyntax
   object serverBuilder extends ServerBuilderSyntax
+
+  /// Shared helpers
+
+  private[syntax] def serverResource[F[_]: Sync, SB <: ServerBuilder[SB]](builder: SB): Resource[F, Server] =
+    serverResourceWithShutdown[F, SB](builder) { server =>
+      Sync[F].delay {
+        server.shutdown()
+        if (!blocking(server.awaitTermination(30, TimeUnit.SECONDS))) {
+          server.shutdownNow()
+          ()
+        }
+      }
+    }
+
+  private[syntax] def serverResourceWithShutdown[F[_]: Sync, SB <: ServerBuilder[SB]](builder: SB)(
+      shutdown: Server => F[Unit]
+  ): Resource[F, Server] =
+    Resource.make(Sync[F].delay(builder.build()))(shutdown)
+
+  //
+
+  private[syntax] def channelResource[F[_]: Sync, MCB <: ManagedChannelBuilder[MCB]](
+      builder: MCB
+  ): Resource[F, ManagedChannel] =
+    channelResourceWithShutdown[F, MCB](builder) { ch =>
+      Sync[F].delay {
+        ch.shutdown()
+        if (!blocking(ch.awaitTermination(30, TimeUnit.SECONDS))) {
+          ch.shutdownNow()
+          ()
+        }
+      }
+    }
+
+  private[syntax] def channelResourceWithShutdown[F[_]: Sync, MCB <: ManagedChannelBuilder[MCB]](builder: MCB)(
+      shutdown: ManagedChannel => F[Unit]
+  ): Resource[F, ManagedChannel] =
+    Resource.make(Sync[F].delay(builder.build()))(shutdown)
+
 }


### PR DESCRIPTION
 - split syntax into Scala3 and Scala2 code such
   that implicit syntax is only used for Scala2.