### PR TITLE
deps: upgrade to scalapb 0.11.0

### DIFF
--- a/java-gen/src/main/scala/Fs2CodeGenerator.scala
+++ b/java-gen/src/main/scala/Fs2CodeGenerator.scala
@@ -22,7 +22,7 @@ object Fs2CodeGenerator extends ProtocCodeGenerator {
     file.getServices.asScala.map { service =>
       val p = new Fs2GrpcServicePrinter(service, fs2params.serviceSuffix, di)
 
-      import di.{ServiceDescriptorPimp, FileDescriptorPimp}
+      import di.{ExtendedServiceDescriptor, ExtendedFileDescriptor}
       val code = p.printService(FunctionalPrinter()).result()
       val b = CodeGeneratorResponse.File.newBuilder()
       b.setName(file.scalaDirectory + "/" + service.name + s"${fs2params.serviceSuffix}.scala")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val minitest = "2.9.3"
 
     val kindProjector = "0.10.3"
-    val sbtProtoc = "1.0.1"
+    val sbtProtoc = "1.0.2"
 
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,4 +10,4 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
 
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.16")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.11"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.0"


### PR DESCRIPTION
@rossabaker This requires a v0.10.0 tag as ScalaPB 0.11.0 is a breaking change, and it seems logical to go with 0.10.0 here. All dependencies from here on are minor bumps in series/0.x. Would great to get a 0.10.0 version published :)

A v0.9.1 would probably be nice for https://github.com/fiadliel/fs2-grpc/pull/325